### PR TITLE
feat: new custom chart components

### DIFF
--- a/custom-metrics-generator/Chart.yaml
+++ b/custom-metrics-generator/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: custom-metrics-generator
+description: A Helm chart for Kubernetes
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.3.2"

--- a/custom-metrics-generator/templates/daemonset.yaml
+++ b/custom-metrics-generator/templates/daemonset.yaml
@@ -1,0 +1,56 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: {{ .Values.name }}
+  labels:
+    k8s-app: node-exporter
+spec:
+  selector:
+    matchLabels:
+      name: {{ .Values.name }}
+  template:
+    metadata:
+      labels:
+        name: {{ .Values.name }}
+    spec:
+      tolerations:
+      - key: node-role.kubernetes.io/control-plane
+        operator: Exists
+        effect: NoSchedule
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+        - name: {{ .Values.name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+        {{- if .Values.env }}
+          env:
+          {{- range $key, $value := .Values.env }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+          {{- end }}
+        {{- end }}
+          livenessProbe:
+            exec:
+              command:
+              - cat
+              - /opt/custom-metrics-generator/custom-metrics-generator.stdout.log
+          readinessProbe:
+            exec:
+              command:
+              - cat
+              - /opt/custom-metrics-generator/custom-metrics-generator.stdout.log
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.volumeMounts }}
+          volumeMounts:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      terminationGracePeriodSeconds: 30
+      {{- with .Values.volumes }}
+      volumes:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/custom-metrics-generator/values.yaml
+++ b/custom-metrics-generator/values.yaml
@@ -1,0 +1,39 @@
+# Default values for custom-metrics-generator.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+name: custom-metrics-generator
+
+image:
+  repository: registry.gitlab.ics.muni.cz:443/cloud/custom-metrics-generator
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+env: {}
+securityContext: {}
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi

--- a/custom-openstack-exporter/.helmignore
+++ b/custom-openstack-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/custom-openstack-exporter/Chart.yaml
+++ b/custom-openstack-exporter/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: custom-openstack-exporter
+description: A Helm chart for custom-openstack-exporter
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.1.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "1.4.2"

--- a/custom-openstack-exporter/templates/NOTES.txt
+++ b/custom-openstack-exporter/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "custom-openstack-exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch the status of by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "custom-openstack-exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "custom-openstack-exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "custom-openstack-exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/custom-openstack-exporter/templates/_helpers.tpl
+++ b/custom-openstack-exporter/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "custom-openstack-exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "custom-openstack-exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "custom-openstack-exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "custom-openstack-exporter.labels" -}}
+helm.sh/chart: {{ include "custom-openstack-exporter.chart" . }}
+{{ include "custom-openstack-exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "custom-openstack-exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "custom-openstack-exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "custom-openstack-exporter.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "custom-openstack-exporter.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/custom-openstack-exporter/templates/deployment.yaml
+++ b/custom-openstack-exporter/templates/deployment.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "custom-openstack-exporter.fullname" . }}
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "custom-openstack-exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "custom-openstack-exporter.labels" . | nindent 8 }}
+	{{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "custom-openstack-exporter.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: openstack-config
+              mountPath: /etc/openstack
+          {{- with .Values.volumeMounts }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+      volumes:
+      - name: openstack-config
+        secret:
+          secretName: openstack-clouds-config
+      {{- with .Values.volumes }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/custom-openstack-exporter/templates/hpa.yaml
+++ b/custom-openstack-exporter/templates/hpa.yaml
@@ -1,0 +1,32 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "custom-openstack-exporter.fullname" . }}
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "custom-openstack-exporter.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.autoscaling.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.autoscaling.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/custom-openstack-exporter/templates/ingress.yaml
+++ b/custom-openstack-exporter/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "custom-openstack-exporter.fullname" . -}}
+{{- $svcPort := .Values.service.port -}}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          - path: {{ .path }}
+            {{- if and .pathType (semverCompare ">=1.18-0" $.Capabilities.KubeVersion.GitVersion) }}
+            pathType: {{ .pathType }}
+            {{- end }}
+            backend:
+              {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.GitVersion }}
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: {{ $svcPort }}
+              {{- else }}
+              serviceName: {{ $fullName }}
+              servicePort: {{ $svcPort }}
+              {{- end }}
+          {{- end }}
+    {{- end }}
+{{- end }}

--- a/custom-openstack-exporter/templates/secret.yaml
+++ b/custom-openstack-exporter/templates/secret.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openstack-clouds-config
+type: Opaque
+stringData:
+  clouds.yaml: |
+    {{- toYaml .Values.clouds_yaml | nindent 4 }}

--- a/custom-openstack-exporter/templates/service.yaml
+++ b/custom-openstack-exporter/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "custom-openstack-exporter.fullname" . }}
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "custom-openstack-exporter.selectorLabels" . | nindent 4 }}

--- a/custom-openstack-exporter/templates/serviceaccount.yaml
+++ b/custom-openstack-exporter/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "custom-openstack-exporter.serviceAccountName" . }}
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+{{- end }}

--- a/custom-openstack-exporter/templates/tests/test-connection.yaml
+++ b/custom-openstack-exporter/templates/tests/test-connection.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "custom-openstack-exporter.fullname" . }}-test-connection"
+  labels:
+    {{- include "custom-openstack-exporter.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+    - name: wget
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "custom-openstack-exporter.fullname" . }}:{{ .Values.service.port }}']
+  restartPolicy: Never

--- a/custom-openstack-exporter/values.yaml
+++ b/custom-openstack-exporter/values.yaml
@@ -1,0 +1,113 @@
+# Default values for custom-openstack-exporter.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+image:
+  repository: registry.gitlab.ics.muni.cz:443/cloud/custom-openstack-exporter
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Automatically mount a ServiceAccount's API credentials?
+  automount: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations:
+  prometheus.io/scrape: 'true'
+  prometheus.io/port: '9877'
+  prometheus.io/path: '/'
+podLabels: {}
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000
+
+service:
+  type: ClusterIP
+  port: 9877
+
+ingress:
+  enabled: false
+  className: ""
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths:
+        - path: /
+          pathType: ImplementationSpecific
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  # requests:
+  #   cpu: 100m
+  #   memory: 128Mi
+
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  maxReplicas: 100
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+# Additional volumes on the output Deployment definition.
+volumes: []
+# - name: foo
+#   secret:
+#     secretName: mysecret
+#     optional: false
+
+# Additional volumeMounts on the output Deployment definition.
+volumeMounts: []
+# - name: foo
+#   mountPath: "/etc/foo"
+#   readOnly: true
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+clouds_yaml:
+  clouds:
+    openstack:
+      region_name: your-region-here
+      auth:
+        username: your-user-here
+        password: your-password-here
+        project_name: your-project-here
+        project_domain_name: 'Default'
+        user_domain_name: 'Default'
+        auth_url: 'http://your-url-here:5000/v3'

--- a/esaco/.helmignore
+++ b/esaco/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/esaco/Chart.yaml
+++ b/esaco/Chart.yaml
@@ -1,0 +1,26 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+appVersion: 0.0.6
+description: ESACO OAuth introspection proxy
+name: esaco
+version: 0.0.6-4
+home: https://gitlab.ics.muni.cz/cloud/esaco
+sources:
+  - https://gitlab.ics.muni.cz/cloud/esaco
+  - https://github.com/indigo-iam/esaco
+  - https://gitlab.ics.muni.cz/cloud/g2/custom-helm-charts
+  - https://github.com/beskar-cloud/custom-helm-charts
+maintainers:
+  - name: e-INFRA CZ cloud team

--- a/esaco/templates/deployment.yaml
+++ b/esaco/templates/deployment.yaml
@@ -1,0 +1,76 @@
+{{- if .Values.manifests.deployment }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.name }}
+spec:
+  replicas: {{ .Values.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      {{- toYaml .Values.deployment.labels | nindent 6 }}
+  strategy:
+    # keep N instances up even when upgrading, upgrade one by one
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+    type: RollingUpdate
+  template:
+    metadata:
+      annotations:
+        checksum/configuration: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum | quote }}
+        {{- if .Values.deployment.podAnnotations }}
+        {{- toYaml .Values.deployment.podAnnotations | nindent 8 }}
+        {{- end }}
+      labels:
+        {{- toYaml .Values.deployment.labels | nindent 8 }}
+    spec:
+      containers:
+      - image: {{ .Values.image.repository }}:{{ .Values.image.tag }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        name: {{ .Values.name }}
+        env:
+        - name: ESACO_USER_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              key: ESACO_USER_PASSWORD
+              name: {{ .Values.name }}
+        {{range $key, $value := .Values.configuration.env_vars -}}
+        {{- if not (eq $key "ESACO_USER_PASSWORD") -}}
+        - name: {{ $key }}
+          value: {{ $value | quote }}
+        {{ end -}}
+        {{ end -}}
+        ports:
+        - containerPort: {{ .Values.configuration.env_vars.ESACO_BIND_PORT | default 8080 }}
+          protocol: TCP
+        resources:
+          {{- toYaml .Values.deployment.resources | nindent 10 }}
+        livenessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - "curl http://127.0.0.1:${ESACO_BIND_PORT}/ | grep -E 'status.?:401'"
+          periodSeconds: 10
+          timeoutSeconds: 2
+        readinessProbe:
+          exec:
+            command:
+            - bash
+            - -c
+            - "curl http://127.0.0.1:${ESACO_BIND_PORT}/ | grep -E 'status.?:401'"
+          periodSeconds: 20
+          timeoutSeconds: 2
+        volumeMounts:
+        - mountPath: /esaco/config/application.yml
+          name: {{ .Values.name }}
+          subPath: application.yml
+          readOnly: true
+      volumes:
+      - name: {{ .Values.name }}
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.name }}
+      nodeSelector:
+        {{- toYaml .Values.deployment.nodeSelector | nindent 8 }}
+{{- end }}

--- a/esaco/templates/namespace.yaml
+++ b/esaco/templates/namespace.yaml
@@ -1,0 +1,6 @@
+{{- if and .Values.manifests.namespace .Values.namespace.name }}
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {{ .Values.namespace.name }}
+{{- end }}

--- a/esaco/templates/secret.yaml
+++ b/esaco/templates/secret.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.manifests.secret }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.name }}
+stringData:
+  ESACO_USER_PASSWORD: {{ .Values.configuration.env_vars.ESACO_USER_PASSWORD }}
+  application.yml: |
+{{- with . -}}
+{{- $templateRendered := tpl ( .Values.configuration.oidc_providers | toYaml ) . }}
+{{- if hasPrefix "|\n" $templateRendered }}
+{{ $templateRendered | trimPrefix "|\n" | indent 2 }}
+{{- else }}
+{{ $templateRendered | indent 2 }}
+{{- end -}}
+{{- end -}}
+
+{{- end }}

--- a/esaco/templates/service.yaml
+++ b/esaco/templates/service.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.manifests.service }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.name }}
+spec:
+  internalTrafficPolicy: Cluster
+  ipFamilies:
+  - IPv4
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.service.loadBalancerIP.enabled }}
+  externalTrafficPolicy: Cluster
+  loadBalancerIP: {{ .Values.service.loadBalancerIP.ip }}
+  allocateLoadBalancerNodePorts: {{ .Values.service.loadBalancerIP.allocateLoadBalancerNodePorts }}
+  {{- end }}
+  {{ if .Values.service.clusterIP }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{ end }}
+  ports:
+  - port: {{ .Values.service.port }}
+    protocol: TCP
+    targetPort: {{ .Values.configuration.env_vars.ESACO_BIND_PORT | default 8080 }}
+    name: http
+  selector:
+    {{- toYaml .Values.service.selector | nindent 4 }}
+  sessionAffinity: None
+  type: {{ .Values.service.type }}
+{{- end }}

--- a/esaco/test/values.yaml
+++ b/esaco/test/values.yaml
@@ -1,0 +1,17 @@
+# raw values injected by Flux CD
+configuration_values:
+  e_infra_cz:
+    client_id: "ABC"         # secret/openstack/keystone-apache-oidc-metadata/oidc_api_client_id
+    client_secret: "A0B1C2"  # secret/openstack/keystone-apache-oidc-metadata/oidc_api_client_secret
+configuration:
+  # templated app configuration
+  oidc_providers: |
+    oidc:
+      clients:
+      - issuer-url: https://login.e-infra.cz/oidc/
+        client-id: {{ .Values.configuration_values.e_infra_cz.client_id }}
+        client-secret: {{ .Values.configuration_values.e_infra_cz.client_secret }}
+  env_vars:
+    ESACO_BIND_PORT: 8080
+    #ESACO_USER_NAME: ""      # configmap/openstack/common/esaco.username
+    #ESACO_USER_PASSWORD: ""  # secret/openstack/common/esaco.password

--- a/esaco/values.yaml
+++ b/esaco/values.yaml
@@ -1,0 +1,73 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+name: &app esaco
+
+configuration:
+  # Use note: ESACO application accepts YAML config file
+  # Unfortunatelly Flux CD fails to inject path oidc_providers.oidc.clients[0].client-id from cm/secret
+  # Therefore yaml structure is here as templated string, see test/values.yaml for an example
+  oidc_providers: |
+    oidc:
+      clients:
+      - issuer-url: https://login.e-infra.cz/oidc/
+        client-id: 2-a-b-z
+        client-secret: f-2-4-8-b-e-4-9-9
+  env_vars:
+    ESACO_BIND_PORT: 8080
+    ESACO_CACHE: "caffeine"
+    ESACO_TLS_VERSION: "TLSv1.2"
+    ESACO_USER_NAME: "change-me-username"      # changeme: use proper username
+    ESACO_USER_PASSWORD: "change-me-password"  # changeme: use proper password
+    ESACO_ENABLE_BASIC_AUTH: 'true'
+    ESACO_USE_FORWARD_HEADERS: 'true'
+    ESACO_CACHE_SPEC: "maximumSize=500,expireAfterWrite=60s"
+    ESACO_BIND_ADDRESS: "0.0.0.0"
+
+image:
+  repository: registry.gitlab.ics.muni.cz:443/cloud/esaco
+  tag: 0-0-6
+  pullPolicy: IfNotPresent
+
+namespace:
+  name: null                # extra namespace is by default disabled
+
+deployment:
+  replicaCount: 2
+  labels:
+    app: *app
+  podAnnotations: {}
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  resources:
+    limits:
+      cpu: 2.0
+      memory: 2.0Gi
+    requests:
+      cpu: 1.0
+      memory: 1.0Gi
+
+service:
+  loadBalancerIP:
+    enabled: false
+  clusterIP: null
+  selector:
+    app: *app
+  type: ClusterIP
+  port: 80
+
+manifests:
+  namespace: true
+  service: true
+  deployment: true
+  secret: true

--- a/prometheus-alertmanager/Chart.yaml
+++ b/prometheus-alertmanager/Chart.yaml
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+appVersion: v0.20.0
+description: OpenStack-Helm Alertmanager for Prometheus (w/o apache proxy)
+name: prometheus-alertmanager
+version: 0.1.9-2
+home: https://prometheus.io/docs/alerting/alertmanager/
+sources:
+  - https://github.com/prometheus/alertmanager
+  - https://opendev.org/openstack/openstack-helm-infra
+maintainers:
+  - name: OpenStack-Helm Authors
+...

--- a/prometheus-alertmanager/requirements.yaml
+++ b/prometheus-alertmanager/requirements.yaml
@@ -1,0 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+dependencies:
+  - name: helm-toolkit
+    repository: file://../helm-toolkit
+    version: ">= 0.1.0"
+...

--- a/prometheus-alertmanager/templates/_helpers.tpl
+++ b/prometheus-alertmanager/templates/_helpers.tpl
@@ -1,0 +1,87 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{/*
+abstract: |
+  Renders out configuration sections into a format suitable for incorporation
+  into a config-map. Allowing various forms of input to be rendered out as
+  appropriate.
+values: |
+  conf:
+    inputs:
+      - foo
+      - bar
+    some:
+      config_to_render: |
+        #We can use all of gotpl here: eg macros, ranges etc.
+        {{ include "helm-toolkit.utils.joinListWithComma" .Values.conf.inputs }}
+      config_to_complete:
+        #here we can fill out params, but things need to be valid yaml as input
+        '{{ .Release.Name }}': '{{ printf "%s-%s" .Release.Namespace "namespace" }}'
+      static_config:
+        #this is just passed though as yaml to the configmap
+        foo: bar
+usage: |
+  {{- $envAll := . }}
+  ---
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: application-etc
+  data:
+  {{- include "helm-toolkit.snippets.values_template_renderer" (dict "envAll" $envAll "template" .Values.conf.some.config_to_render "key" "config_to_render.conf") | indent 2 }}
+  {{- include "helm-toolkit.snippets.values_template_renderer" (dict "envAll" $envAll "template" .Values.conf.some.config_to_complete "key" "config_to_complete.yaml") | indent 2 }}
+  {{- include "helm-toolkit.snippets.values_template_renderer" (dict "envAll" $envAll "template" .Values.conf.some.static_config "key" "static_config.yaml") | indent 2 }}
+return: |
+  ---
+  apiVersion: v1
+  kind: ConfigMap
+  metadata:
+    name: application-etc
+  data:
+    config_to_render.conf: |
+      #We can use all of gotpl here: eg macros, ranges etc.
+      foo,bar
+
+    config_to_complete.yaml: |
+      'RELEASE-NAME': 'default-namespace'
+
+    static_config.yaml: |
+      foo: bar
+*/}}
+
+{{- define "values_template_renderer_template_in_template" -}}
+{{- $envAll := index . "envAll" -}}
+{{- $template := index . "template" -}}
+{{- $key := index . "key" -}}
+{{- $format := index . "format" | default "configMap" -}}
+{{- with $envAll -}}
+{{- $templateRendered := tpl ( $template | toYaml ) . }}
+{{- if eq $format "Secret" }}
+{{- if hasPrefix "|\n" $templateRendered }}
+{{ $key }}: {{ regexReplaceAllLiteral "\n  " ( $templateRendered | trimPrefix "|\n" | trimPrefix "  " ) "\n" | replace "{_{" "{{" | replace "}_}" "}}" | b64enc }}
+{{- else }}
+{{ $key }}: {{ $templateRendered | replace "{_{" "{{" | replace "}_}" "}}" | b64enc }}
+{{- end -}}
+{{- else }}
+{{- if hasPrefix "|\n" $templateRendered }}
+{{ $key }}: |
+{{ regexReplaceAllLiteral "\n  " ( $templateRendered | trimPrefix "|\n" | trimPrefix "  " ) "\n" | replace "{_{" "{{" | replace "}_}" "}}" | indent 2 }}
+{{- else }}
+{{ $key }}: |
+{{ $templateRendered | replace "{_{" "{{" | replace "}_}" "}}" | indent 2 }}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/prometheus-alertmanager/templates/bin/_alertmanager.sh.tpl
+++ b/prometheus-alertmanager/templates/bin/_alertmanager.sh.tpl
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+set -ex
+COMMAND="${@:-start}"
+
+function start () {
+  exec /bin/alertmanager \
+    --config.file=/etc/alertmanager/config.yml \
+{{- range $flag, $value := .Values.conf.command_flags.alertmanager }}
+{{- $flag := $flag | replace "_" "-" }}
+{{ printf "--%s=%s" $flag $value | indent 4 }} \
+{{- end }}
+    $(generate_peers)
+}
+
+function generate_peers () {
+  final_pod_suffix=$(( {{ .Values.pod.replicas.alertmanager }}-1 ))
+  for pod_suffix in `seq 0 "$final_pod_suffix"`
+  do
+    echo --cluster.peer=prometheus-alertmanager-$pod_suffix.$DISCOVERY_SVC:$MESH_PORT
+  done
+}
+
+function stop () {
+  kill -TERM 1
+}
+
+$COMMAND

--- a/prometheus-alertmanager/templates/bin/_apache.sh.tpl
+++ b/prometheus-alertmanager/templates/bin/_apache.sh.tpl
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+set -exv
+
+COMMAND="${@:-start}"
+
+function start () {
+
+  if [ -f /etc/apache2/envvars ]; then
+     # Loading Apache2 ENV variables
+     source /etc/httpd/apache2/envvars
+  fi
+  # Apache gets grumpy about PID files pre-existing
+  rm -f /etc/httpd/logs/httpd.pid
+
+  if [ -f /usr/local/apache2/conf/.htpasswd ]; then
+    htpasswd -b /usr/local/apache2/conf/.htpasswd "$ALERTMANAGER_USERNAME" "$ALERTMANAGER_PASSWORD"
+  else
+    htpasswd -cb /usr/local/apache2/conf/.htpasswd "$ALERTMANAGER_USERNAME" "$ALERTMANAGER_PASSWORD"
+  fi
+
+  #Launch Apache on Foreground
+  exec httpd -DFOREGROUND
+}
+
+function stop () {
+  apachectl -k graceful-stop
+}
+
+$COMMAND

--- a/prometheus-alertmanager/templates/clusterrolebinding.yaml
+++ b/prometheus-alertmanager/templates/clusterrolebinding.yaml
@@ -1,0 +1,31 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.clusterrolebinding }}
+{{- $envAll := . }}
+{{- $serviceAccountName := printf "%s" "prometheus-alertmanager" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: run-alertmanager
+subjects:
+  - kind: ServiceAccount
+    name: {{ $serviceAccountName }}
+    namespace: {{ $envAll.Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: cluster-admin
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/prometheus-alertmanager/templates/configmap-bin.yaml
+++ b/prometheus-alertmanager/templates/configmap-bin.yaml
@@ -1,0 +1,29 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.configmap_bin }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "alertmanager-bin" | quote }}
+data:
+  apache.sh: |
+{{ tuple "bin/_apache.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  alertmanager.sh: |
+{{ tuple "bin/_alertmanager.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  image-repo-sync.sh: |
+{{- include "helm-toolkit.scripts.image_repo_sync" . | indent 4 }}
+{{- end }}

--- a/prometheus-alertmanager/templates/configmap-etc.yaml
+++ b/prometheus-alertmanager/templates/configmap-etc.yaml
@@ -1,0 +1,28 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.configmap_etc }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "alertmanager-etc" | quote }}
+data:
+{{- include "values_template_renderer_template_in_template" (dict "envAll" $envAll "template" .Values.conf.alertmanager "key" "config.yml" "format" "Secret") | indent 2 }}
+{{- if .Values.conf.alert_templates }}
+{{- include "values_template_renderer_template_in_template" (dict "envAll" $envAll "template" .Values.conf.alert_templates "key" "alert-templates.tmpl" "format" "Secret") | indent 2 }}
+{{- end }}
+{{- include "values_template_renderer_template_in_template" (dict "envAll" $envAll "template" .Values.conf.httpd "key" "httpd.conf" "format" "Secret") | indent 2 }}
+{{- end }}

--- a/prometheus-alertmanager/templates/ingress-alertmanager.yaml
+++ b/prometheus-alertmanager/templates/ingress-alertmanager.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.ingress .Values.network.alertmanager.ingress.public }}
+{{- $ingressOpts := dict "envAll" . "backendService" "alertmanager" "backendServiceType" "alertmanager" "backendPort" "http" -}}
+{{ $ingressOpts | include "helm-toolkit.manifests.ingress" }}
+{{- end }}

--- a/prometheus-alertmanager/templates/job-image-repo-sync.yaml
+++ b/prometheus-alertmanager/templates/job-image-repo-sync.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.job_image_repo_sync .Values.images.local_registry.active }}
+{{- $imageRepoSyncJob := dict "envAll" . "serviceName" "alertmanager" -}}
+{{ $imageRepoSyncJob | include "helm-toolkit.manifests.job_image_repo_sync" }}
+{{- end }}

--- a/prometheus-alertmanager/templates/network_policy.yaml
+++ b/prometheus-alertmanager/templates/network_policy.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */}}
+
+{{- if .Values.manifests.network_policy -}}
+{{- $netpol_opts := dict "envAll" . "name" "application" "label" "alertmanager" -}}
+{{ $netpol_opts | include "helm-toolkit.manifests.kubernetes_network_policy" }}
+{{- end -}}

--- a/prometheus-alertmanager/templates/secret-admin-user.yaml
+++ b/prometheus-alertmanager/templates/secret-admin-user.yaml
@@ -1,0 +1,26 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.secret_admin_user }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "admin-user" | quote }}
+type: Opaque
+data:
+  ALERTMANAGER_USERNAME: {{ .Values.endpoints.alertmanager.auth.admin.username | b64enc }}
+  ALERTMANAGER_PASSWORD: {{ .Values.endpoints.alertmanager.auth.admin.password | b64enc }}
+{{- end }}

--- a/prometheus-alertmanager/templates/secret-ingress-tls.yaml
+++ b/prometheus-alertmanager/templates/secret-ingress-tls.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.secret_ingress_tls }}
+{{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "alertmanager" "backendService" "alertmanager") }}
+{{- end }}

--- a/prometheus-alertmanager/templates/secret-registry.yaml
+++ b/prometheus-alertmanager/templates/secret-registry.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.secret_registry .Values.endpoints.oci_image_registry.auth.enabled }}
+{{ include "helm-toolkit.manifests.secret_registry" ( dict "envAll" . "registryUser" .Chart.Name ) }}
+{{- end }}

--- a/prometheus-alertmanager/templates/service-discovery.yaml
+++ b/prometheus-alertmanager/templates/service-discovery.yaml
@@ -1,0 +1,30 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.service_discovery }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ tuple "alertmanager" "discovery" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+  - name: peer-mesh
+    port: {{ tuple "alertmanager" "internal" "mesh" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+  selector:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+{{- end }}

--- a/prometheus-alertmanager/templates/service-ingress-alertmanager.yaml
+++ b/prometheus-alertmanager/templates/service-ingress-alertmanager.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.service_ingress .Values.network.alertmanager.ingress.public }}
+{{- $serviceIngressOpts := dict "envAll" . "backendServiceType" "alertmanager" -}}
+{{ $serviceIngressOpts | include "helm-toolkit.manifests.service_ingress" }}
+{{- end }}

--- a/prometheus-alertmanager/templates/service.yaml
+++ b/prometheus-alertmanager/templates/service.yaml
@@ -1,0 +1,40 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.service }}
+{{- $envAll := . }}
+{{- $prometheus_annotations := $envAll.Values.monitoring.prometheus.prometheus }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ tuple "alertmanager" "internal" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+  annotations:
+{{- if .Values.monitoring.prometheus.enabled }}
+{{ tuple $prometheus_annotations | include "helm-toolkit.snippets.prometheus_service_annotations" | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: http
+    port: 80
+    targetPort: {{ tuple "alertmanager" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+    {{ if .Values.network.alertmanager.node_port.enabled }}
+    nodePort: {{ .Values.network.alertmanager.node_port.port }}
+    {{ end }}
+  selector:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  {{ if .Values.network.alertmanager.node_port.enabled }}
+  type: NodePort
+  {{ end }}
+{{- end }}

--- a/prometheus-alertmanager/templates/statefulset.yaml
+++ b/prometheus-alertmanager/templates/statefulset.yaml
@@ -1,0 +1,152 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.statefulset }}
+{{- $envAll := . }}
+
+{{- $mounts_alertmanager := .Values.pod.mounts.alertmanager.alertmanager }}
+{{- $mounts_alertmanager_init := .Values.pod.mounts.alertmanager.init_container }}
+
+{{- $serviceAccountName := "prometheus-alertmanager" }}
+{{ tuple $envAll "prometheus-alertmanager" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: prometheus-alertmanager
+  annotations:
+    {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
+  labels:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+spec:
+  serviceName: {{ tuple "alertmanager" "discovery" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+  podManagementPolicy: "Parallel"
+  replicas: {{ .Values.pod.replicas.alertmanager }}
+  selector:
+    matchLabels:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+{{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
+        configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "helm-toolkit.utils.hash" }}
+{{ dict "envAll" $envAll "podName" $serviceAccountName "containerNames" (list "prometheus-alertmanager" "prometheus-alertmanager-perms" "init") | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 8 }}
+    spec:
+{{ dict "envAll" $envAll "application" "server" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
+      serviceAccountName: {{ $serviceAccountName }}
+      affinity:
+{{ tuple $envAll "prometheus-alertmanager" "server" | include "helm-toolkit.snippets.kubernetes_pod_anti_affinity" | indent 8 }}
+      nodeSelector:
+        {{ .Values.labels.alertmanager.node_selector_key }}: {{ .Values.labels.alertmanager.node_selector_value | quote }}
+      terminationGracePeriodSeconds: {{ .Values.pod.lifecycle.termination_grace_period.alertmanager.timeout | default "30" }}
+      initContainers:
+{{ tuple $envAll "alertmanager" list | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        - name: prometheus-alertmanager-perms
+{{ tuple $envAll "prometheus-alertmanager" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ tuple $envAll $envAll.Values.pod.resources.alertmanager | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
+{{ dict "envAll" $envAll "application" "server" "container" "prometheus_alertmanager_perms" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - chown
+            - -R
+            - "nobody:"
+            - /var/lib/alertmanager/data
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: alertmanager-data
+              mountPath: /var/lib/alertmanager/data
+      containers:
+        - name: prometheus-alertmanager
+{{ tuple $envAll "prometheus-alertmanager" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ tuple $envAll $envAll.Values.pod.resources.alertmanager | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
+{{ dict "envAll" $envAll "application" "server" "container" "prometheus_alertmanager" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - /tmp/alertmanager.sh
+            - start
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /tmp/alertmanager.sh
+                  - stop
+          env:
+            - name: DISCOVERY_SVC
+              value: {{ tuple "alertmanager" "discovery" . | include "helm-toolkit.endpoints.hostname_fqdn_endpoint_lookup" }}
+            - name: MESH_PORT
+              value: {{ tuple "alertmanager" "internal" "mesh" . | include "helm-toolkit.endpoints.endpoint_port_lookup" | quote }}
+          ports:
+            - name: alerts-api
+              containerPort: {{ tuple "alertmanager" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+            - name: peer-mesh
+              containerPort: {{ tuple "alertmanager" "internal" "mesh" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+          readinessProbe:
+            httpGet:
+              path: /#/status
+              port: {{ tuple "alertmanager" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: etc-alertmanager
+              mountPath: /etc/config
+            {{- if .Values.conf.alert_templates }}
+            - name: alertmanager-etc
+              mountPath: /etc/alertmanager/template/alert-templates.tmpl
+              subPath: alert-templates.tmpl
+              readOnly: true
+            {{- end }}
+            - name: alertmanager-etc
+              mountPath: /etc/alertmanager/config.yml
+              subPath: config.yml
+              readOnly: true
+            - name: alertmanager-bin
+              mountPath: /tmp/alertmanager.sh
+              subPath: alertmanager.sh
+              readOnly: true
+            - name: alertmanager-data
+              mountPath: /var/lib/alertmanager/data
+{{ if $mounts_alertmanager.volumeMounts }}{{ toYaml $mounts_alertmanager.volumeMounts | indent 12 }}{{ end }}
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: etc-alertmanager
+          emptyDir: {}
+        - name: alertmanager-etc
+          secret:
+            secretName: {{ printf "%s-%s" $envAll.Release.Name "alertmanager-etc" | quote }}
+            defaultMode: 0444
+        - name: alertmanager-bin
+          configMap:
+            name: {{ printf "%s-%s" $envAll.Release.Name "alertmanager-bin" | quote }}
+            defaultMode: 0555
+{{ if $mounts_alertmanager.volumes }}{{ toYaml $mounts_alertmanager.volumes | indent 8 }}{{ end }}
+{{- if not .Values.storage.alertmanager.enabled }}
+        - name: alertmanager-data
+          emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: alertmanager-data
+      spec:
+        accessModes: {{ .Values.storage.alertmanager.pvc.access_mode }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.alertmanager.requests.storage  }}
+        storageClassName: {{ .Values.storage.alertmanager.storage_class }}
+{{- end }}
+{{- end }}

--- a/prometheus-alertmanager/values.yaml
+++ b/prometheus-alertmanager/values.yaml
@@ -1,0 +1,482 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for alertmanager.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+---
+images:
+  tags:
+    apache_proxy: docker.io/library/httpd:2.4
+    prometheus-alertmanager: docker.io/prom/alertmanager:v0.20.0
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+    image_repo_sync: docker.io/library/docker:17.07.0
+  pull_policy: IfNotPresent
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+labels:
+  alertmanager:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+
+pod:
+  security_context:
+    server:
+      pod:
+        runAsUser: 65534
+      container:
+        prometheus_alertmanager_perms:
+          runAsUser: 0
+          readOnlyRootFilesystem: true
+        apache_proxy:
+          runAsUser: 0
+          readOnlyRootFilesystem: false
+        prometheus_alertmanager:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+  affinity:
+    anti:
+      type:
+        default: preferredDuringSchedulingIgnoredDuringExecution
+      topologyKey:
+        default: kubernetes.io/hostname
+      weight:
+        default: 10
+  mounts:
+    alertmanager:
+      alertmanager:
+      init_container: null
+  replicas:
+    alertmanager: 1
+  lifecycle:
+    upgrades:
+      deployment:
+        pod_replacement_strategy: RollingUpdate
+      statefulsets:
+        pod_replacement_strategy: RollingUpdate
+    termination_grace_period:
+      alertmanager:
+        timeout: 30
+  resources:
+    enabled: false
+    apache_proxy:
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+      requests:
+        memory: "128Mi"
+        cpu: "100m"
+    alertmanager:
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+    jobs:
+      image_repo_sync:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+
+endpoints:
+  cluster_domain_suffix: cluster.local
+  local_image_registry:
+    name: docker-registry
+    namespace: docker-registry
+    hosts:
+      default: localhost
+      internal: docker-registry
+      node: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        node: 5000
+  oci_image_registry:
+    name: oci-image-registry
+    namespace: oci-image-registry
+    auth:
+      enabled: false
+      prometheus-alertmanager:
+        username: prometheus-alertmanager
+        password: password
+    hosts:
+      default: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        default: null
+  alertmanager:
+    name: prometheus-alertmanager
+    namespace: null
+    auth:
+      admin:
+        username: admin
+        password: changeme
+    hosts:
+      default: alerts-engine
+      public: prometheus-alertmanager
+      discovery: prometheus-alertmanager-discovery
+    host_fqdn_override:
+      default: null
+      # NOTE(srwilkers): this chart supports TLS for fqdn over-ridden public
+      # endpoints using the following format:
+      # public:
+      #   host: null
+      #   tls:
+      #     crt: null
+      #     key: null
+    path:
+      default: null
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 9093
+        public: 80
+      mesh:
+        default: 9094
+      http:
+        default: 80
+  ldap:
+    hosts:
+      default: ldap
+    auth:
+      admin:
+        bind: "cn=admin,dc=cluster,dc=local"
+        password: password
+    host_fqdn_override:
+      default: null
+    path:
+      default: "/ou=People,dc=cluster,dc=local"
+    scheme:
+      default: ldap
+    port:
+      ldap:
+        default: 389
+
+dependencies:
+  dynamic:
+    common:
+      local_image_registry:
+        jobs:
+          - alertmanager-image-repo-sync
+        services:
+          - endpoint: node
+            service: local_image_registry
+  static:
+    alertmanager:
+      services: null
+    image_repo_sync:
+      services:
+        - endpoint: internal
+          service: local_image_registry
+
+network:
+  alertmanager:
+    ingress:
+      public: true
+      classes:
+        namespace: "nginx"
+        cluster: "nginx-cluster"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+    node_port:
+      enabled: false
+      port: 30903
+
+secrets:
+  oci_image_registry:
+    prometheus-alertmanager: prometheus-alertmanager-oci-image-registry-key
+  tls:
+    alertmanager:
+      alertmanager:
+        public: alerts-tls-public
+
+storage:
+  alertmanager:
+    enabled: true
+    pvc:
+      access_mode: ["ReadWriteOnce"]
+    requests:
+      storage: 5Gi
+    storage_class: general
+
+manifests:
+  clusterrolebinding: true
+  configmap_bin: true
+  configmap_etc: true
+  ingress: true
+  job_image_repo_sync: true
+  network_policy: false
+  secret_admin_user: true
+  secret_ingress_tls: true
+  secret_registry: true
+  service: true
+  service_discovery: true
+  service_ingress: true
+  statefulset: true
+
+network_policy:
+  alertmanager:
+    ingress:
+      - {}
+    egress:
+      - {}
+
+monitoring:
+  prometheus:
+    enabled: true
+    prometheus:
+      scrape: true
+
+conf:
+  httpd: |
+    ServerRoot "/usr/local/apache2"
+
+    Listen 80
+
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule authn_file_module modules/mod_authn_file.so
+    LoadModule authn_core_module modules/mod_authn_core.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    LoadModule access_compat_module modules/mod_access_compat.so
+    LoadModule auth_basic_module modules/mod_auth_basic.so
+    LoadModule ldap_module modules/mod_ldap.so
+    LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+    LoadModule reqtimeout_module modules/mod_reqtimeout.so
+    LoadModule filter_module modules/mod_filter.so
+    LoadModule proxy_html_module modules/mod_proxy_html.so
+    LoadModule log_config_module modules/mod_log_config.so
+    LoadModule env_module modules/mod_env.so
+    LoadModule headers_module modules/mod_headers.so
+    LoadModule setenvif_module modules/mod_setenvif.so
+    LoadModule version_module modules/mod_version.so
+    LoadModule proxy_module modules/mod_proxy.so
+    LoadModule proxy_connect_module modules/mod_proxy_connect.so
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+    LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+    LoadModule remoteip_module modules/mod_remoteip.so
+    LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+    LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+    LoadModule unixd_module modules/mod_unixd.so
+    LoadModule status_module modules/mod_status.so
+    LoadModule autoindex_module modules/mod_autoindex.so
+
+    <IfModule unixd_module>
+    User daemon
+    Group daemon
+    </IfModule>
+
+    <Directory />
+        AllowOverride none
+        Require all denied
+    </Directory>
+
+    <Files ".ht*">
+        Require all denied
+    </Files>
+
+    ErrorLog /dev/stderr
+
+    LogLevel warn
+
+    <IfModule log_config_module>
+        LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+        LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+        <IfModule logio_module>
+          LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+        </IfModule>
+
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout common
+        CustomLog /dev/stdout combined
+        CustomLog /dev/stdout proxy env=forwarded
+    </IfModule>
+
+    <Directory "/usr/local/apache2/cgi-bin">
+        AllowOverride None
+        Options None
+        Require all granted
+    </Directory>
+
+    <IfModule headers_module>
+        RequestHeader unset Proxy early
+    </IfModule>
+
+    <IfModule proxy_html_module>
+    Include conf/extra/proxy-html.conf
+    </IfModule>
+
+    <VirtualHost *:80>
+      RemoteIPHeader X-Original-Forwarded-For
+      <Location />
+          ProxyPass http://localhost:{{ tuple "alertmanager" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+          ProxyPassReverse http://localhost:{{ tuple "alertmanager" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+      </Location>
+      <Proxy *>
+          AuthName "Alertmanager"
+          AuthType Basic
+          AuthBasicProvider file ldap
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          AuthLDAPBindDN {{ .Values.endpoints.ldap.auth.admin.bind }}
+          AuthLDAPBindPassword {{ .Values.endpoints.ldap.auth.admin.password }}
+          AuthLDAPURL {{ tuple "ldap" "default" "ldap" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | quote }}
+          Require valid-user
+      </Proxy>
+    </VirtualHost>
+  command_flags:
+    alertmanager:
+      storage.path: /var/lib/alertmanager/data
+      cluster.listen_address: "0.0.0.0:9094"
+  # alertmanager configuration may contain go templating, to avoid collision with helm templating use {_{ ... }_} instead of {{ ... }}
+  alertmanager: |
+    global:
+      # The smarthost and SMTP sender used for mail notifications.
+      smtp_smarthost: 'localhost:25'
+      smtp_from: 'alertmanager@example.org'
+      smtp_auth_username: 'alertmanager'
+      smtp_auth_password: 'password'
+      # The auth token for Hipchat.
+      hipchat_auth_token: '1234556789'
+      # Alternative host for Hipchat.
+      hipchat_api_url: 'https://hipchat.foobar.org/'
+    # The directory from which notification templates are read.
+    templates:
+      - '/etc/alertmanager/template/*.tmpl'
+    # The root route on which each incoming alert enters.
+    route:
+      # The labels by which incoming alerts are grouped together. For example,
+      # multiple alerts coming in for cluster=A and alertname=LatencyHigh would
+      # be batched into a single group.
+      group_by:
+        - alertname
+        - cluster
+        - service
+      # When a new group of alerts is created by an incoming alert, wait at
+      # least 'group_wait' to send the initial notification.
+      # This way ensures that you get multiple alerts for the same group that start
+      # firing shortly after another are batched together on the first
+      # notification.
+      group_wait: 30s
+      # When the first notification was sent, wait 'group_interval' to send a batch
+      # of new alerts that started firing for that group.
+      group_interval: 5m
+      # If an alert has successfully been sent, wait 'repeat_interval' to
+      # resend them.
+      repeat_interval: 3h
+      # A default receiver
+      # receiver: team-X-mails
+      receiver: 'team-X-mails'
+      # All the above attributes are inherited by all child routes and can
+      # overwritten on each.
+      # The child route trees.
+      routes:
+        # This routes performs a regular expression match on alert
+        # labels to catch alerts that are related to a list of
+        # services.
+        - receiver: 'team-X-mails'
+          continue: true
+        - match_re:
+            service: ^(foo1|foo2|baz)$
+          receiver: team-X-mails
+          # The service has a sub-route for critical alerts, any alerts
+          # that do not match, i.e. severity != critical, fall-back to the
+          # parent node and are sent to 'team-X-mails'
+          routes:
+            - match:
+                severity: critical
+              receiver: team-X-pager
+        - match:
+            service: files
+          receiver: team-Y-mails
+          routes:
+            - match:
+                severity: critical
+              receiver: team-Y-pager
+        # This route handles all alerts coming from a database service. If there's
+        # no team to handle it, it defaults to the DB team.
+        - match:
+            service: database
+          receiver: team-DB-pager
+          # Also group alerts by affected database.
+          group_by:
+            - alertname
+            - cluster
+            - database
+          routes:
+            - match:
+                owner: team-X
+              receiver: team-X-pager
+            - match:
+                owner: team-Y
+              receiver: team-Y-pager
+    # Inhibition rules allow to mute a set of alerts given that another alert is
+    # firing.
+    # We use this to mute any warning-level notifications if the same alert is
+    # already critical.
+    inhibit_rules:
+      - source_match:
+          severity: 'critical'
+        target_match:
+          severity: 'warning'
+        # Apply inhibition if the alertname is the same.
+        equal:
+          - alertname
+          - cluster
+          - service
+    receivers:
+      - name: 'team-X-mails'
+        email_configs:
+          - to: 'team-X+alerts@example.org'
+      - name: 'team-X-pager'
+        email_configs:
+          - to: 'team-X+alerts-critical@example.org'
+        pagerduty_configs:
+          - service_key: <team-X-key>
+      - name: 'team-Y-mails'
+        email_configs:
+          - to: 'team-Y+alerts@example.org'
+      - name: 'team-Y-pager'
+        pagerduty_configs:
+          - service_key: <team-Y-key>
+      - name: 'team-DB-pager'
+        pagerduty_configs:
+          - service_key: <team-DB-key>
+      - name: 'team-X-hipchat'
+        hipchat_configs:
+          - auth_token: <auth_token>
+            room_id: 85
+            message_format: html
+            notify: false
+  # alertmanager alert-templates contain go templating, to avoid collision with helm templating use {_{ ... }_} instead of {{ ... }}
+  alert_templates: null
+...

--- a/prometheus-alertmanager/values_overrides/apparmor.yaml
+++ b/prometheus-alertmanager/values_overrides/apparmor.yaml
@@ -1,0 +1,9 @@
+---
+pod:
+  mandatory_access_control:
+    type: apparmor
+    prometheus-alertmanager:
+      prometheus-alertmanager: runtime/default
+      prometheus-alertmanager-perms: runtime/default
+      init: runtime/default
+...

--- a/prometheus/Chart.yaml
+++ b/prometheus/Chart.yaml
@@ -1,0 +1,25 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: v1
+appVersion: v2.25.0
+description: OpenStack-Helm Prometheus (w/o apache proxy)
+name: prometheus
+version: 0.1.13-2
+home: https://prometheus.io/
+sources:
+  - https://github.com/prometheus/prometheus
+  - https://opendev.org/openstack/openstack-helm-infra
+maintainers:
+  - name: OpenStack-Helm Authors
+...

--- a/prometheus/requirements.yaml
+++ b/prometheus/requirements.yaml
@@ -1,0 +1,18 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+dependencies:
+  - name: helm-toolkit
+    repository: file://../helm-toolkit
+    version: ">= 0.1.0"
+...

--- a/prometheus/templates/bin/_apache.sh.tpl
+++ b/prometheus/templates/bin/_apache.sh.tpl
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+set -ev
+
+COMMAND="${@:-start}"
+
+function start () {
+
+  if [ -f /etc/apache2/envvars ]; then
+     # Loading Apache2 ENV variables
+     source /etc/httpd/apache2/envvars
+  fi
+  # Apache gets grumpy about PID files pre-existing
+  rm -f /etc/httpd/logs/httpd.pid
+
+  if [ -f /usr/local/apache2/conf/.htpasswd ]; then
+    htpasswd -b /usr/local/apache2/conf/.htpasswd "$PROMETHEUS_ADMIN_USERNAME" "$PROMETHEUS_ADMIN_PASSWORD"
+  else
+    htpasswd -cb /usr/local/apache2/conf/.htpasswd "$PROMETHEUS_ADMIN_USERNAME" "$PROMETHEUS_ADMIN_PASSWORD"
+  fi
+
+  if [ -n "$PROMETHEUS_FEDERATE_USERNAME" ]; then
+    htpasswd -b /usr/local/apache2/conf/.htpasswd "$PROMETHEUS_FEDERATE_USERNAME" "$PROMETHEUS_FEDERATE_PASSWORD"
+  fi
+
+  #Launch Apache on Foreground
+  exec httpd -DFOREGROUND
+}
+
+function stop () {
+  apachectl -k graceful-stop
+}
+
+$COMMAND

--- a/prometheus/templates/bin/_helm-tests.sh.tpl
+++ b/prometheus/templates/bin/_helm-tests.sh.tpl
@@ -1,0 +1,60 @@
+#!/bin/bash
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+
+set -ex
+
+function endpoints_up () {
+  endpoints_result=$(curl ${CACERT_OPTION} -K- <<< "--user ${PROMETHEUS_ADMIN_USERNAME}:${PROMETHEUS_ADMIN_PASSWORD}" \
+    "${PROMETHEUS_ENDPOINT}/api/v1/query?query=up" \
+    | python -c "import sys, json; print(json.load(sys.stdin)['status'])")
+  if [ "$endpoints_result" = "success" ];
+  then
+    echo "PASS: Endpoints successfully queried!"
+  else
+    echo "FAIL: Endpoints not queried!";
+    exit 1;
+  fi
+}
+
+function get_targets () {
+  targets_result=$(curl ${CACERT_OPTION} -K- <<< "--user ${PROMETHEUS_ADMIN_USERNAME}:${PROMETHEUS_ADMIN_PASSWORD}" \
+    "${PROMETHEUS_ENDPOINT}/api/v1/targets" \
+    | python -c "import sys, json; print(json.load(sys.stdin)['status'])")
+  if [ "$targets_result" = "success" ];
+  then
+    echo "PASS: Targets successfully queried!"
+  else
+    echo "FAIL: Endpoints not queried!";
+    exit 1;
+  fi
+}
+
+function get_alertmanagers () {
+  alertmanager=$(curl ${CACERT_OPTION} -K- <<< "--user ${PROMETHEUS_ADMIN_USERNAME}:${PROMETHEUS_ADMIN_PASSWORD}" \
+    "${PROMETHEUS_ENDPOINT}/api/v1/alertmanagers" \
+    |  python -c "import sys, json; print(json.load(sys.stdin)['status'])")
+  if [ "$alertmanager" = "success" ];
+  then
+    echo "PASS: Alertmanager successfully queried!"
+  else
+    echo "FAIL: Alertmanager not queried!";
+    exit 1;
+  fi
+}
+
+endpoints_up
+get_targets
+get_alertmanagers

--- a/prometheus/templates/bin/_prometheus.sh.tpl
+++ b/prometheus/templates/bin/_prometheus.sh.tpl
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+set -ex
+COMMAND="${@:-start}"
+
+function start () {
+{{ $flags := include "prometheus.utils.command_line_flags" .Values.conf.prometheus.command_line_flags }}
+  exec /bin/prometheus --config.file=/etc/config/prometheus.yml {{ $flags }}
+}
+
+function stop () {
+  kill -TERM 1
+}
+
+$COMMAND

--- a/prometheus/templates/certificates.yaml
+++ b/prometheus/templates/certificates.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.certificates -}}
+{{  dict "envAll" . "service" "monitoring" "type" "internal" | include "helm-toolkit.manifests.certificates" }}
+{{- end -}}

--- a/prometheus/templates/configmap-bin.yaml
+++ b/prometheus/templates/configmap-bin.yaml
@@ -1,0 +1,31 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.configmap_bin }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "prometheus-bin" | quote }}
+data:
+  apache.sh: |
+{{ tuple "bin/_apache.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  prometheus.sh: |
+{{ tuple "bin/_prometheus.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  helm-tests.sh: |
+{{ tuple "bin/_helm-tests.sh.tpl" . | include "helm-toolkit.utils.template" | indent 4 }}
+  image-repo-sync.sh: |
+{{- include "helm-toolkit.scripts.image_repo_sync" . | indent 4 }}
+{{- end }}

--- a/prometheus/templates/configmap-etc.yaml
+++ b/prometheus/templates/configmap-etc.yaml
@@ -1,0 +1,30 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.configmap_etc }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "prometheus-etc" | quote }}
+type: Opaque
+data:
+{{- include "helm-toolkit.snippets.values_template_renderer" (dict "envAll" $envAll "template" .Values.conf.prometheus.scrape_configs.template "key" "prometheus.yml" "format" "Secret") | indent 2 }}
+{{ range $key, $value := .Values.conf.prometheus.rules }}
+  {{ $key }}.rules: {{ toYaml $value | b64enc }}
+{{ end }}
+  # NOTE(srwilkers): this must be last, to work round helm ~2.7 bug.
+{{- include "helm-toolkit.snippets.values_template_renderer" (dict "envAll" $envAll "template" .Values.conf.httpd "key" "httpd.conf" "format" "Secret") | indent 2 }}
+{{- end }}

--- a/prometheus/templates/ingress-prometheus.yaml
+++ b/prometheus/templates/ingress-prometheus.yaml
@@ -1,0 +1,24 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.ingress .Values.network.prometheus.ingress.public }}
+{{- $envAll := . -}}
+{{- $port := tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_scheme_lookup" }}
+{{- $ingressOpts := dict "envAll" $envAll "backendService" "prometheus" "backendServiceType" "monitoring" "backendPort" $port -}}
+{{- $secretName := $envAll.Values.secrets.tls.monitoring.prometheus.internal -}}
+{{- if and .Values.manifests.certificates $secretName -}}
+{{- $_ := set $ingressOpts "certIssuer" .Values.endpoints.monitoring.host_fqdn_override.default.tls.issuerRef.name -}}
+{{- end -}}
+{{ $ingressOpts | include "helm-toolkit.manifests.ingress" }}
+{{- end }}

--- a/prometheus/templates/job-image-repo-sync.yaml
+++ b/prometheus/templates/job-image-repo-sync.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.job_image_repo_sync .Values.images.local_registry.active }}
+{{- $imageRepoSyncJob := dict "envAll" . "serviceName" "prometheus" -}}
+{{ $imageRepoSyncJob | include "helm-toolkit.manifests.job_image_repo_sync" }}
+{{- end }}

--- a/prometheus/templates/network_policy.yaml
+++ b/prometheus/templates/network_policy.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License. */}}
+
+{{- if .Values.manifests.network_policy -}}
+{{- $netpol_opts := dict "envAll" . "name" "application" "label" "prometheus" -}}
+{{ $netpol_opts | include "helm-toolkit.manifests.kubernetes_network_policy" }}
+{{- end -}}

--- a/prometheus/templates/pod-helm-tests.yaml
+++ b/prometheus/templates/pod-helm-tests.yaml
@@ -1,0 +1,80 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.helm_tests }}
+{{- $envAll := . }}
+
+{{- $serviceAccountName := print .Release.Name "-test" }}
+{{ tuple $envAll "tests" $serviceAccountName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{.Release.Name}}-test"
+  labels:
+{{ tuple $envAll "prometheus" "test" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  annotations:
+    {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
+{{ dict "envAll" $envAll "podName" "prometheus-test" "containerNames" (list "init" "prometheus-helm-tests") | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 4 }}
+    "helm.sh/hook": test-success
+spec:
+{{ dict "envAll" $envAll "application" "test" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 2 }}
+  serviceAccountName: {{ $serviceAccountName }}
+  nodeSelector:
+    {{ .Values.labels.test.node_selector_key }}: {{ .Values.labels.test.node_selector_value }}
+  restartPolicy: Never
+  initContainers:
+{{ tuple $envAll "tests" list | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 4 }}
+  containers:
+    - name: prometheus-helm-tests
+{{ tuple $envAll "helm_tests" | include "helm-toolkit.snippets.image" | indent 6 }}
+{{ tuple $envAll $envAll.Values.pod.resources.jobs.tests | include "helm-toolkit.snippets.kubernetes_resources" | indent 6 }}
+{{ dict "envAll" $envAll "application" "test" "container" "prometheus_helm_tests" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 6 }}
+      command:
+        - /tmp/helm-tests.sh
+      env:
+        - name: PROMETHEUS_ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" $envAll.Release.Name "admin-user" | quote }}
+              key: PROMETHEUS_ADMIN_USERNAME
+        - name: PROMETHEUS_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: {{ printf "%s-%s" $envAll.Release.Name "admin-user" | quote }}
+              key: PROMETHEUS_ADMIN_PASSWORD
+
+{{- if .Values.manifests.certificates }}
+        - name: CACERT_OPTION
+          value: "--cacert /etc/prometheus/certs/ca.crt"
+{{- end }}
+        - name: PROMETHEUS_ENDPOINT
+          value: {{ printf "%s://%s" (tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_scheme_lookup") (tuple "monitoring" "internal" . | include "helm-toolkit.endpoints.hostname_fqdn_endpoint_lookup") }}
+      volumeMounts:
+        - name: pod-tmp
+          mountPath: /tmp
+        - name: prometheus-bin
+          mountPath: /tmp/helm-tests.sh
+          subPath: helm-tests.sh
+          readOnly: true
+{{- dict "enabled" .Values.manifests.certificates "name" .Values.secrets.tls.monitoring.prometheus.internal "path" "/etc/prometheus/certs" | include "helm-toolkit.snippets.tls_volume_mount" | indent 8 }}
+  volumes:
+    - name: pod-tmp
+      emptyDir: {}
+    - name: prometheus-bin
+      configMap:
+        name: {{ printf "%s-%s" $envAll.Release.Name "prometheus-bin" | quote }}
+        defaultMode: 0555
+{{- dict "enabled" .Values.manifests.certificates "name" .Values.secrets.tls.monitoring.prometheus.internal | include "helm-toolkit.snippets.tls_volume" | indent 4 }}
+{{- end }}

--- a/prometheus/templates/secret-ingress-tls.yaml
+++ b/prometheus/templates/secret-ingress-tls.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.secret_ingress_tls }}
+{{- include "helm-toolkit.manifests.secret_ingress_tls" ( dict "envAll" . "backendServiceType" "monitoring" "backendService" "prometheus" ) }}
+{{- end }}

--- a/prometheus/templates/secret-prometheus.yaml
+++ b/prometheus/templates/secret-prometheus.yaml
@@ -1,0 +1,28 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.secret_prometheus }}
+{{- $envAll := . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-%s" $envAll.Release.Name "admin-user" | quote }}
+type: Opaque
+data:
+  PROMETHEUS_ADMIN_USERNAME: {{ .Values.endpoints.monitoring.auth.admin.username | b64enc }}
+  PROMETHEUS_ADMIN_PASSWORD: {{ .Values.endpoints.monitoring.auth.admin.password | b64enc }}
+  PROMETHEUS_FEDERATE_USERNAME: {{ .Values.endpoints.monitoring.auth.federate.username | b64enc }}
+  PROMETHEUS_FEDERATE_PASSWORD: {{ .Values.endpoints.monitoring.auth.federate.password | b64enc }}
+{{- end }}

--- a/prometheus/templates/secret-registry.yaml
+++ b/prometheus/templates/secret-registry.yaml
@@ -1,0 +1,17 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.secret_registry .Values.endpoints.oci_image_registry.auth.enabled }}
+{{ include "helm-toolkit.manifests.secret_registry" ( dict "envAll" . "registryUser" .Chart.Name ) }}
+{{- end }}

--- a/prometheus/templates/secret-tls-configs.yaml
+++ b/prometheus/templates/secret-tls-configs.yaml
@@ -1,0 +1,27 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.tls_configs }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-tls-configs
+data:
+{{- range $k, $v := .Values.tls_configs }}
+{{- range $f, $c := $v }}
+  {{ $k }}.{{ $f }}: {{ $c | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/prometheus/templates/service-ingress-prometheus.yaml
+++ b/prometheus/templates/service-ingress-prometheus.yaml
@@ -1,0 +1,18 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if and .Values.manifests.service_ingress .Values.network.prometheus.ingress.public }}
+{{- $serviceIngressOpts := dict "envAll" . "backendServiceType" "monitoring" -}}
+{{ $serviceIngressOpts | include "helm-toolkit.manifests.service_ingress" }}
+{{- end }}

--- a/prometheus/templates/service.yaml
+++ b/prometheus/templates/service.yaml
@@ -1,0 +1,42 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- if .Values.manifests.service }}
+{{- $envAll := . }}
+{{- $prometheus_annotations := $envAll.Values.monitoring.prometheus.prometheus }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ tuple "monitoring" "internal" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+  labels:
+{{ tuple $envAll "prometheus" "metrics" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  annotations:
+{{- if .Values.monitoring.prometheus.enabled }}
+{{ tuple $prometheus_annotations | include "helm-toolkit.snippets.prometheus_service_annotations" | indent 4 }}
+{{- end }}
+spec:
+  ports:
+  - name: {{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_scheme_lookup" }}
+    port: {{ tuple "monitoring" "internal" "http" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+    targetPort: {{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+    {{ if .Values.network.prometheus.node_port.enabled }}
+    nodePort: {{ .Values.network.prometheus.node_port.port }}
+    {{ end }}
+  selector:
+{{ tuple $envAll "prometheus" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+  {{ if .Values.network.prometheus.node_port.enabled }}
+  type: NodePort
+  {{ end }}
+{{- end }}

--- a/prometheus/templates/statefulset.yaml
+++ b/prometheus/templates/statefulset.yaml
@@ -1,0 +1,287 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+{{- define "probeTemplate" }}
+{{- $probePort := tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+{{- $probeUser := .Values.endpoints.monitoring.auth.admin.username }}
+{{- $probePass := .Values.endpoints.monitoring.auth.admin.password }}
+{{- $authHeader := printf "%s:%s" $probeUser $probePass | b64enc }}
+httpGet:
+  path: /-/ready
+  scheme: {{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.keystone_endpoint_scheme_lookup" | upper }}
+  port: {{ $probePort }}
+{{- end }}
+
+
+{{- if .Values.manifests.statefulset_prometheus }}
+{{- $envAll := . }}
+
+{{- $mounts_prometheus := .Values.pod.mounts.prometheus.prometheus }}
+{{- $mounts_prometheus_init := .Values.pod.mounts.prometheus.init_container }}
+
+{{- $rcControllerName := printf "%s-%s" $envAll.Release.Name "prometheus" }}
+{{ tuple $envAll "prometheus" $rcControllerName | include "helm-toolkit.snippets.kubernetes_pod_rbac_serviceaccount" }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ $rcControllerName | quote }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+      - nodes/proxy
+      - services
+      - endpoints
+      - pods
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+    verbs:
+      - get
+  - nonResourceURLs:
+      - "/metrics"
+    verbs:
+      - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ $rcControllerName | quote }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $rcControllerName | quote }}
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: {{ $rcControllerName | quote }}
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ $rcControllerName | quote }}
+  annotations:
+    {{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" }}
+  labels:
+{{ tuple $envAll "prometheus" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 4 }}
+spec:
+  serviceName: {{ tuple "monitoring" "internal" . | include "helm-toolkit.endpoints.hostname_short_endpoint_lookup" }}
+  podManagementPolicy: "Parallel"
+  replicas: {{ .Values.pod.replicas.prometheus }}
+  selector:
+    matchLabels:
+{{ tuple $envAll "prometheus" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 6 }}
+  template:
+    metadata:
+      labels:
+{{ tuple $envAll "prometheus" "api" | include "helm-toolkit.snippets.kubernetes_metadata_labels" | indent 8 }}
+      annotations:
+        prometheus.io/scrape: 'true'
+        prometheus.io/port: '9090'
+{{ tuple $envAll | include "helm-toolkit.snippets.release_uuid" | indent 8 }}
+        configmap-bin-hash: {{ tuple "configmap-bin.yaml" . | include "helm-toolkit.utils.hash" }}
+        configmap-etc-hash: {{ tuple "configmap-etc.yaml" . | include "helm-toolkit.utils.hash" }}
+{{ dict "envAll" $envAll "podName" "prometheus" "containerNames" (list "prometheus" "prometheus-perms" "apache-proxy" "init") | include "helm-toolkit.snippets.kubernetes_mandatory_access_control_annotation" | indent 8 }}
+    spec:
+{{ dict "envAll" $envAll "application" "api" | include "helm-toolkit.snippets.kubernetes_pod_security_context" | indent 6 }}
+      serviceAccountName: {{ $rcControllerName | quote }}
+      affinity:
+{{ tuple $envAll "prometheus" "api" | include "helm-toolkit.snippets.kubernetes_pod_anti_affinity" | indent 8 }}
+      nodeSelector:
+        {{ .Values.labels.prometheus.node_selector_key }}: {{ .Values.labels.prometheus.node_selector_value | quote }}
+      terminationGracePeriodSeconds: {{ .Values.pod.lifecycle.termination_grace_period.prometheus.timeout | default "30" }}
+      initContainers:
+{{ tuple $envAll "prometheus" list | include "helm-toolkit.snippets.kubernetes_entrypoint_init_container" | indent 8 }}
+        - name: prometheus-perms
+{{ tuple $envAll "prometheus" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ tuple $envAll $envAll.Values.pod.resources.prometheus | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
+{{ dict "envAll" $envAll "application" "api" "container" "prometheus_perms" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - chown
+            - -R
+            - "nobody:"
+            - /var/lib/prometheus/data
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: storage
+              mountPath: /var/lib/prometheus/data
+      containers:
+        {{- if .Values.prometheus.thanos.create }}
+        - name: thanos-sidecar
+          image: {{ .Values.prometheus.thanos.image.registry }}/{{ .Values.prometheus.thanos.image.repository }}:{{ .Values.prometheus.thanos.image.tag }}
+          imagePullPolicy: {{ .Values.prometheus.thanos.image.pullPolicy }}
+          args:
+            - sidecar
+            - --prometheus.url={{ default "http://localhost:9090" .Values.prometheus.thanos.prometheusUrl }}
+            - --grpc-address=0.0.0.0:10901
+            - --http-address=0.0.0.0:10902
+            - --tsdb.path=/prometheus/
+            {{- if .Values.prometheus.thanos.objectStorageConfig.secretName }}
+            - --objstore.config=$(OBJSTORE_CONFIG)
+            {{- end }}
+            {{- if .Values.prometheus.thanos.extraArgs }}
+            {{ toYaml .Values.prometheus.thanos.extraArgs | indent 8  | trim }}
+            {{- end }}
+          {{- if .Values.prometheus.thanos.objectStorageConfig.secretName }}
+          env:
+            - name: OBJSTORE_CONFIG
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.prometheus.thanos.objectStorageConfig.secretName }}
+                  key: {{ .Values.prometheus.thanos.objectStorageConfig.secretKey | default "thanos.yaml" }}
+          {{- end }}
+          {{- if .Values.prometheus.thanos.resources }}
+          resources:
+            {{- toYaml .Values.prometheus.thanos.resources | nindent 12 }}
+          {{- end }}
+          ports:
+            - name: grpc
+              containerPort: 10901
+              protocol: TCP
+            - name: http
+              containerPort: 10902
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /prometheus
+              name: storage
+            {{- if .Values.prometheus.thanos.extraVolumeMounts }}
+            {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.extraVolumeMounts "context" $) | nindent 8 }}
+            {{- end }}
+          {{- if .Values.prometheus.thanos.containerSecurityContext.enabled }}
+          # yamllint disable rule:indentation
+          securityContext:
+            {{- omit .Values.prometheus.thanos.containerSecurityContext "enabled" | toYaml | nindent 12 }}
+          # yamllint enable rule:indentation
+          {{- end }}
+          {{- if .Values.prometheus.thanos.livenessProbe.enabled }}
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.prometheus.thanos.livenessProbe.path }}
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.prometheus.thanos.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheus.thanos.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheus.thanos.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.prometheus.thanos.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.prometheus.thanos.livenessProbe.successThreshold }}
+          {{- end }}
+          {{- if .Values.prometheus.thanos.readinessProbe.enabled }}
+          readinessProbe:
+            httpGet:
+              path: {{ .Values.prometheus.thanos.readinessProbe.path }}
+              port: http
+              scheme: HTTP
+            initialDelaySeconds: {{ .Values.prometheus.thanos.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.prometheus.thanos.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.prometheus.thanos.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.prometheus.thanos.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.prometheus.thanos.readinessProbe.successThreshold }}
+          {{- end }}
+        {{- end }}
+        - name: prometheus
+{{ tuple $envAll "prometheus" | include "helm-toolkit.snippets.image" | indent 10 }}
+{{ tuple $envAll $envAll.Values.pod.resources.prometheus | include "helm-toolkit.snippets.kubernetes_resources" | indent 10 }}
+{{ dict "envAll" $envAll "application" "api" "container" "prometheus" | include "helm-toolkit.snippets.kubernetes_container_security_context" | indent 10 }}
+          command:
+            - /tmp/prometheus.sh
+            - start
+          lifecycle:
+            preStop:
+              exec:
+                command:
+                  - /tmp/prometheus.sh
+                  - stop
+          ports:
+            - name: prom-metrics
+              containerPort: {{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}
+{{ dict "envAll" . "component" "prometheus" "container" "prometheus" "type" "readiness" "probeTemplate" (include "probeTemplate" . | fromYaml) | include "helm-toolkit.snippets.kubernetes_probe" | indent 10 }}
+{{ dict "envAll" . "component" "prometheus" "container" "prometheus" "type" "liveness" "probeTemplate" (include "probeTemplate" . | fromYaml) | include "helm-toolkit.snippets.kubernetes_probe" | indent 10 }}
+          env:
+{{- if .Values.pod.env.prometheus }}
+{{ include "helm-toolkit.utils.to_k8s_env_vars" .Values.pod.env.prometheus | indent 12 }}
+{{- end }}
+          volumeMounts:
+            - name: pod-tmp
+              mountPath: /tmp
+            - name: etcprometheus
+              mountPath: /etc/config
+            - name: rulesprometheus
+              mountPath: /etc/config/rules
+            {{- range $key, $value := .Values.conf.prometheus.rules }}
+            - name: prometheus-etc
+              mountPath: /etc/config/rules/{{ $key }}.rules
+              subPath: {{ $key }}.rules
+              readOnly: true
+            {{- end }}
+            - name: prometheus-etc
+              mountPath: /etc/config/prometheus.yml
+              subPath: prometheus.yml
+              readOnly: true
+            - name: prometheus-bin
+              mountPath: /tmp/prometheus.sh
+              subPath: prometheus.sh
+              readOnly: true
+            - name: storage
+              mountPath: /var/lib/prometheus/data
+{{- if .Values.tls_configs }}
+            - name: tls-configs
+              mountPath: /tls_configs
+{{- end }}
+{{ if $mounts_prometheus.volumeMounts }}{{ toYaml $mounts_prometheus.volumeMounts | indent 12 }}{{ end }}
+      volumes:
+        - name: pod-tmp
+          emptyDir: {}
+        - name: etcprometheus
+          emptyDir: {}
+        - name: rulesprometheus
+          emptyDir: {}
+        - name: prometheus-etc
+          secret:
+            secretName: {{ printf "%s-%s" $envAll.Release.Name "prometheus-etc" | quote }}
+            defaultMode: 0444
+{{- dict "enabled" .Values.manifests.certificates "name" .Values.secrets.tls.monitoring.prometheus.internal | include "helm-toolkit.snippets.tls_volume" | indent 8 }}
+        - name: prometheus-bin
+          configMap:
+            name: {{ printf "%s-%s" $envAll.Release.Name "prometheus-bin" | quote }}
+            defaultMode: 0555
+{{- if .Values.tls_configs }}
+        - name: tls-configs
+          secret:
+            secretName: {{ printf "%s-%s" $envAll.Release.Name "tls-configs" | quote }}
+            defaultMode: 0444
+{{- end }}
+{{ if $mounts_prometheus.volumes }}{{ toYaml $mounts_prometheus.volumes | indent 8 }}{{ end }}
+{{- if not .Values.storage.enabled }}
+        - name: storage
+          emptyDir: {}
+{{- else }}
+  volumeClaimTemplates:
+    - metadata:
+        name: storage
+      spec:
+        accessModes: {{ .Values.storage.pvc.access_mode }}
+        resources:
+          requests:
+            storage: {{ .Values.storage.requests.storage  }}
+        storageClassName: {{ .Values.storage.storage_class }}
+{{- end }}
+{{- end }}

--- a/prometheus/templates/thanos-service.yaml
+++ b/prometheus/templates/thanos-service.yaml
@@ -1,0 +1,56 @@
+{{- /*
+Copyright VMware, Inc.
+SPDX-License-Identifier: APACHE-2.0
+*/}}
+
+{{- if .Values.prometheus.thanos.create }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-thanos
+  labels:
+    app.kubernetes.io/subcomponent: thanos
+    {{- if .Values.prometheus.thanos.service.labels }}
+    {{- include "common.tplvalues.render" ( dict "value" .Values.prometheus.thanos.service.labels "context" $ ) | nindent 4 }}
+    {{- end }}
+  {{- if or .Values.prometheus.thanos.service.annotations .Values.commonAnnotations }}
+  {{- $annotations := include "common.tplvalues.merge" ( dict "values" ( list .Values.prometheus.thanos.service.annotations .Values.commonAnnotations ) "context" . ) }}
+  annotations: {{- include "common.tplvalues.render" ( dict "value" $annotations "context" $ ) | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.prometheus.thanos.service.type }}
+  {{- if and (eq .Values.prometheus.thanos.service.type "LoadBalancer") (not (empty .Values.prometheus.thanos.service.loadBalancerIP)) }}
+  loadBalancerIP: {{ .Values.prometheus.thanos.service.loadBalancerIP }}
+  {{- end }}
+  {{- if and (eq .Values.prometheus.thanos.service.type "LoadBalancer") (not (empty .Values.prometheus.thanos.service.loadBalancerClass)) }}
+  loadBalancerClass: {{ .Values.prometheus.thanos.service.loadBalancerClass }}
+  {{- end }}
+  {{- if and (eq .Values.prometheus.thanos.service.type "LoadBalancer") (not (empty .Values.prometheus.thanos.service.loadBalancerSourceRanges)) }}
+  loadBalancerSourceRanges: {{ .Values.prometheus.thanos.service.loadBalancerSourceRanges }}
+  {{- end }}
+  {{- if and .Values.prometheus.thanos.service.clusterIP (eq .Values.prometheus.thanos.service.type "ClusterIP") }}
+  clusterIP: {{ .Values.prometheus.thanos.service.clusterIP }}
+  {{- end }}
+  {{- if .Values.prometheus.thanos.service.sessionAffinity }}
+  sessionAffinity: {{ .Values.prometheus.thanos.service.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.prometheus.thanos.service.sessionAffinityConfig }}
+  sessionAffinityConfig: {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.service.sessionAffinityConfig "context" $) | nindent 4 }}
+  {{- end }}
+  {{- if or (eq .Values.prometheus.thanos.service.type "LoadBalancer") (eq .Values.prometheus.thanos.service.type "NodePort") }}
+  externalTrafficPolicy: {{ .Values.prometheus.thanos.service.externalTrafficPolicy | quote }}
+  {{- end }}
+  ports:
+    - name: grpc
+      port: {{ .Values.prometheus.thanos.service.ports.grpc }}
+      targetPort: grpc
+      protocol: TCP
+      {{- if and .Values.prometheus.thanos.service.nodePorts.grpc (or (eq .Values.prometheus.thanos.service.type "NodePort") (eq .Values.prometheus.thanos.service.type "LoadBalancer")) }}
+      nodePort: {{ .Values.prometheus.thanos.service.nodePorts.grpc }}
+      {{- end }}
+    {{- if .Values.prometheus.thanos.service.extraPorts }}
+    {{- include "common.tplvalues.render" (dict "value" .Values.prometheus.thanos.service.extraPorts "context" $) | nindent 4 }}
+    {{- end }}
+  selector:
+    application: prometheus
+{{- end }}

--- a/prometheus/templates/utils/_command_line_flags.tpl
+++ b/prometheus/templates/utils/_command_line_flags.tpl
@@ -1,0 +1,46 @@
+{{/*
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/}}
+
+# This function generates the command line flags passed to Prometheus at time of
+# execution. This allows the Prometheus service configuration to be flexible, as
+# the only way to define Prometheus's configuration is via command line flags.
+# The yaml definition for these flags uses the full yaml path as the key, and
+# replaces underscores with hyphens to match the syntax required for the flags
+# generated (This is required due to Go's yaml parsing capabilities).
+# For example:
+#
+# conf:
+#   prometheus:
+#     command_line_flags:
+#       storage.tsdb.max_block_duration: 2h
+#
+# Will generate the following flag:
+#   --storage.tsdb.max-block-duration=2h
+#
+# Prometheus's command flags can be found by either running 'prometheus -h' or
+# 'prometheus --help-man'
+
+{{- define "prometheus.utils.command_line_flags" -}}
+{{- range $flag, $value := . -}}
+{{- $flag := $flag | replace "_" "-" }}
+{{- if eq $flag "web.enable-admin-api" "web.enable-lifecycle" "storage.tsdb.wal-compression" -}}
+{{- if $value }}
+{{- printf " --%s " $flag -}}
+{{- end -}}
+{{- else -}}
+{{- $value := $value | toString }}
+{{- printf " --%s=%s " $flag $value }}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/prometheus/values.yaml
+++ b/prometheus/values.yaml
@@ -1,0 +1,1421 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Default values for prometheus.
+# This is a YAML-formatted file.
+# Declare name/value pairs to be passed into your templates.
+# name: value
+
+---
+images:
+  tags:
+    apache_proxy: docker.io/library/httpd:2.4
+    prometheus: docker.io/prom/prometheus:v2.25.0
+    helm_tests: docker.io/openstackhelm/heat:wallaby-ubuntu_focal
+    dep_check: quay.io/airshipit/kubernetes-entrypoint:v1.0.0
+    image_repo_sync: docker.io/library/docker:17.07.0
+  pull_policy: IfNotPresent
+  local_registry:
+    active: false
+    exclude:
+      - dep_check
+      - image_repo_sync
+
+labels:
+  prometheus:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  job:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+  test:
+    node_selector_key: openstack-control-plane
+    node_selector_value: enabled
+
+pod:
+  env:
+    prometheus: null
+  security_context:
+    api:
+      pod:
+        runAsUser: 65534
+      container:
+        prometheus_perms:
+          runAsUser: 0
+          readOnlyRootFilesystem: false
+        apache_proxy:
+          runAsUser: 0
+          readOnlyRootFilesystem: false
+        prometheus:
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: true
+    test:
+      pod:
+        runAsUser: 65534
+      container:
+        prometheus_helm_tests:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+  affinity:
+    anti:
+      type:
+        default: preferredDuringSchedulingIgnoredDuringExecution
+      topologyKey:
+        default: kubernetes.io/hostname
+      weight:
+        default: 10
+  mounts:
+    prometheus:
+      prometheus:
+      init_container: null
+  replicas:
+    prometheus: 1
+  lifecycle:
+    upgrades:
+      statefulsets:
+        pod_replacement_strategy: RollingUpdate
+    termination_grace_period:
+      prometheus:
+        timeout: 30
+  resources:
+    enabled: false
+    prometheus:
+      limits:
+        memory: "1024Mi"
+        cpu: "2000m"
+      requests:
+        memory: "128Mi"
+        cpu: "500m"
+    jobs:
+      image_repo_sync:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+      tests:
+        requests:
+          memory: "128Mi"
+          cpu: "100m"
+        limits:
+          memory: "1024Mi"
+          cpu: "2000m"
+  probes:
+    prometheus:
+      prometheus:
+        readiness:
+          enabled: true
+          params:
+            initialDelaySeconds: 30
+            timeoutSeconds: 30
+        liveness:
+          enabled: false
+          params:
+            initialDelaySeconds: 120
+            timeoutSeconds: 30
+endpoints:
+  cluster_domain_suffix: cluster.local
+  local_image_registry:
+    name: docker-registry
+    namespace: docker-registry
+    hosts:
+      default: localhost
+      internal: docker-registry
+      node: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        node: 5000
+  oci_image_registry:
+    name: oci-image-registry
+    namespace: oci-image-registry
+    auth:
+      enabled: false
+      prometheus:
+        username: prometheus
+        password: password
+    hosts:
+      default: localhost
+    host_fqdn_override:
+      default: null
+    port:
+      registry:
+        default: null
+  monitoring:
+    name: prometheus
+    namespace: null
+    auth:
+      admin:
+        username: admin
+        password: changeme
+      federate:
+        username: federate
+        password: changeme
+    hosts:
+      default: prom-metrics
+      public: prometheus
+    host_fqdn_override:
+      default: null
+      # NOTE(srwilkers): this chart supports TLS for fqdn over-ridden public
+      # endpoints using the following format:
+      # public:
+      #   host: null
+      #   tls:
+      #     crt: null
+      #     key: null
+    path:
+      default: null
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 9090
+      http:
+        default: 80
+  alertmanager:
+    name: prometheus-alertmanager
+    namespace: null
+    hosts:
+      default: alerts-engine
+      public: prometheus-alertmanager
+      discovery: prometheus-alertmanager-discovery
+    host_fqdn_override:
+      default: null
+    path:
+      default: null
+    scheme:
+      default: 'http'
+    port:
+      api:
+        default: 9093
+        public: 80
+      mesh:
+        default: 9094
+  ldap:
+    hosts:
+      default: ldap
+    auth:
+      admin:
+        bind: "cn=admin,dc=cluster,dc=local"
+        password: password
+    host_fqdn_override:
+      default: null
+    path:
+      default: "/ou=People,dc=cluster,dc=local"
+    scheme:
+      default: ldap
+    port:
+      ldap:
+        default: 389
+
+dependencies:
+  dynamic:
+    common:
+      local_image_registry:
+        jobs:
+          - prometheus-image-repo-sync
+        services:
+          - endpoint: node
+            service: local_image_registry
+  static:
+    image_repo_sync:
+      services:
+        - endpoint: internal
+          service: local_image_registry
+    prometheus:
+      services: null
+    tests:
+      services:
+        - endpoint: internal
+          service: monitoring
+
+monitoring:
+  prometheus:
+    enabled: true
+    prometheus:
+      scrape: true
+
+prometheus:
+  ## Thanos sidecar container configuration
+  ##
+  thanos:
+    ## @param prometheus.thanos.create Create a Thanos sidecar container
+    ##
+    create: false
+    ## Bitnami Thanos image
+    ## ref: https://hub.docker.com/r/bitnami/thanos/tags/
+    ## @param prometheus.thanos.image.registry [default: REGISTRY_NAME] Thanos image registry
+    ## @param prometheus.thanos.image.repository [default: REPOSITORY_NAME/thanos] Thanos image name
+    ## @skip prometheus.thanos.image.tag Thanos image tag
+    ## @param prometheus.thanos.image.digest Thanos image digest in the way sha256:aa.... Please note this parameter, if set, will override the tag
+    ## @param prometheus.thanos.image.pullPolicy Thanos image pull policy
+    ## @param prometheus.thanos.image.pullSecrets Specify docker-registry secret names as an array
+    ##
+    image:
+      registry: docker.io
+      repository: bitnami/thanos
+      tag: 0.32.4-debian-11-r3
+      digest: ""
+      ## Specify a imagePullPolicy. Defaults to 'Always' if image tag is 'latest', else set to 'IfNotPresent'
+      ## ref: https://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+      ##
+      pullPolicy: IfNotPresent
+      ## Optionally specify an array of imagePullSecrets.
+      ## Secrets must be manually created in the namespace.
+      ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/
+      ## Example:
+      ## pullSecrets:
+      ##   - myRegistryKeySecretName
+      ##
+      pullSecrets: []
+    ## Thanos Sidecar container's securityContext
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+    ## @param prometheus.thanos.containerSecurityContext.enabled Enable container security context
+    ## @param prometheus.thanos.containerSecurityContext.readOnlyRootFilesystem mount / (root) as a readonly filesystem
+    ## @param prometheus.thanos.containerSecurityContext.allowPrivilegeEscalation Switch privilegeEscalation possibility on or off
+    ## @param prometheus.thanos.containerSecurityContext.runAsNonRoot Force the container to run as a non root user
+    ## @param prometheus.thanos.containerSecurityContext.capabilities.drop [array] Linux Kernel capabilities which should be dropped
+    ##
+    containerSecurityContext:
+      enabled: true
+      readOnlyRootFilesystem: false
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      capabilities:
+        drop:
+          - ALL
+    ## @param prometheus.thanos.prometheusUrl Override default prometheus url `http://localhost:9090`
+    ##
+    prometheusUrl: ""
+    ## @param prometheus.thanos.extraArgs Additional arguments passed to the thanos sidecar container
+    ## extraArgs:
+    ## - --log.level=debug
+    ## - --tsdb.path=/data/
+    ##
+    extraArgs: []
+    ## @param prometheus.thanos.objectStorageConfig.secretName Support mounting a Secret for the objectStorageConfig of the sideCar container.
+    ## @param prometheus.thanos.objectStorageConfig.secretKey Secret key with the configuration file.
+    ## ref: https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/thanos.md
+    ## objectStorageConfig:
+    ##    secretName: thanos-objstore-config
+    ##    secretKey: thanos.yaml
+    ##
+    objectStorageConfig:
+      secretName: ""
+      secretKey: thanos.yaml
+    ## ref: https://github.com/thanos-io/thanos/blob/main/docs/components/sidecar.md
+    ## @param prometheus.thanos.extraVolumeMounts Additional volumeMounts from `prometheus.volumes` for thanos sidecar container
+    ## extraVolumeMounts:
+    ## - name: my-secret-volume
+    ##   mountPath: /etc/thanos/secrets/my-secret
+    ##
+    extraVolumeMounts: []
+    ## Thanos sidecar container resource requests and limits.
+    ## ref: https://kubernetes.io/docs/user-guide/compute-resources/
+    ## We usually recommend not to specify default resources and to leave this as a conscious
+    ## choice for the user. This also increases chances charts run on environments with little
+    ## resources, such as Minikube. If you do want to specify resources, uncomment the following
+    ## lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+    ## @param prometheus.thanos.resources.limits The resources limits for the Thanos sidecar container
+    ## @param prometheus.thanos.resources.requests The resources requests for the Thanos sidecar container
+    ##
+    resources:
+      ## Example:
+      ## limits:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      limits: {}
+      ## Examples:
+      ## requests:
+      ##    cpu: 100m
+      ##    memory: 128Mi
+      ##
+      requests: {}
+    ## Configure extra options for liveness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param prometheus.thanos.livenessProbe.enabled Turn on and off liveness probe
+    ## @param prometheus.thanos.livenessProbe.path Path of the HTTP service for checking the healthy state
+    ## @param prometheus.thanos.livenessProbe.initialDelaySeconds Delay before liveness probe is initiated
+    ## @param prometheus.thanos.livenessProbe.periodSeconds How often to perform the probe
+    ## @param prometheus.thanos.livenessProbe.timeoutSeconds When the probe times out
+    ## @param prometheus.thanos.livenessProbe.failureThreshold Minimum consecutive failures for the probe
+    ## @param prometheus.thanos.livenessProbe.successThreshold Minimum consecutive successes for the probe
+    ##
+    livenessProbe:
+      enabled: true
+      path: /-/healthy
+      initialDelaySeconds: 0
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 120
+      successThreshold: 1
+    ## Configure extra options for readiness probe
+    ## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/#configure-probes
+    ## @param prometheus.thanos.readinessProbe.enabled Turn on and off readiness probe
+    ## @param prometheus.thanos.readinessProbe.path Path of the HTTP service for checking the ready state
+    ## @param prometheus.thanos.readinessProbe.initialDelaySeconds Delay before readiness probe is initiated
+    ## @param prometheus.thanos.readinessProbe.periodSeconds How often to perform the probe
+    ## @param prometheus.thanos.readinessProbe.timeoutSeconds When the probe times out
+    ## @param prometheus.thanos.readinessProbe.failureThreshold Minimum consecutive failures for the probe
+    ## @param prometheus.thanos.readinessProbe.successThreshold Minimum consecutive successes for the probe
+    ##
+    readinessProbe:
+      enabled: true
+      path: /-/ready
+      initialDelaySeconds: 0
+      periodSeconds: 5
+      timeoutSeconds: 3
+      failureThreshold: 120
+      successThreshold: 1
+    ## Thanos Sidecar Service
+    ##
+    service:
+      ## @param prometheus.thanos.service.type Kubernetes service type
+      ##
+      type: ClusterIP
+      ## @param prometheus.thanos.service.ports.grpc Thanos service port
+      ##
+      ports:
+        grpc: 10901
+      ## @param prometheus.thanos.service.clusterIP Specific cluster IP when service type is cluster IP. Use `None` to create headless service by default.
+      ## Use a "headless" service by default so it returns every pod's IP instead of loadbalancing requests.
+      ##
+      clusterIP: None
+      ## @param prometheus.thanos.service.nodePorts.grpc Specify the nodePort value for the LoadBalancer and NodePort service types.
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+      ## e.g:
+      ## nodePort: 30901
+      ##
+      nodePorts:
+        grpc: ""
+      ## @param prometheus.thanos.service.loadBalancerIP `loadBalancerIP` if service type is `LoadBalancer`
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer
+      ##
+      loadBalancerIP: ""
+      ## @param prometheus.thanos.service.loadBalancerClass Thanos service Load Balancer class if service type is `LoadBalancer` (optional, cloud specific)
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+      ##
+      loadBalancerClass: ""
+      ## @param prometheus.thanos.service.loadBalancerSourceRanges Address that are allowed when svc is `LoadBalancer`
+      ## https://kubernetes.io/docs/tasks/access-application-cluster/configure-cloud-provider-firewall/#restrict-access-for-loadbalancer-service
+      ## e.g:
+      ## loadBalancerSourceRanges:
+      ## - 10.10.10.0/24
+      ##
+      loadBalancerSourceRanges: []
+      ## @param prometheus.thanos.service.labels Additional labels for Thanos service
+      ##
+      labels: {}
+      ## @param prometheus.thanos.service.annotations Additional annotations for Thanos service
+      ##
+      annotations: {}
+      ## @param prometheus.thanos.service.extraPorts Additional ports to expose from the Thanos sidecar container
+      ## extraPorts:
+      ##   - name: http
+      ##     port: 10902
+      ##     targetPort: http
+      ##     protocol: TCP
+      ##
+      extraPorts: []
+      ## @param prometheus.thanos.service.externalTrafficPolicy Prometheus service external traffic policy
+      ## ref http://kubernetes.io/docs/tasks/access-application-cluster/create-external-load-balancer/#preserving-the-client-source-ip
+      ##
+      externalTrafficPolicy: Cluster
+      ## @param prometheus.thanos.service.sessionAffinity Session Affinity for Kubernetes service, can be "None" or "ClientIP"
+      ## If "ClientIP", consecutive client requests will be directed to the same Pod
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#virtual-ips-and-service-proxies
+      ##
+      sessionAffinity: None
+      ## @param prometheus.thanos.service.sessionAffinityConfig Additional settings for the sessionAffinity
+      ## sessionAffinityConfig:
+      ##   clientIP:
+      ##     timeoutSeconds: 300
+      ##
+      sessionAffinityConfig: {}
+    ## Configure the ingress resource that allows you to access the
+    ## Thanos Sidecar installation. Set up the URL
+    ## ref: https://kubernetes.io/docs/user-guide/ingress/
+    ##
+    ingress:
+      ## @param prometheus.thanos.ingress.enabled Enable ingress controller resource
+      ##
+      enabled: false
+      ## @param prometheus.thanos.ingress.pathType Ingress path type
+      ##
+      pathType: ImplementationSpecific
+      ## @param prometheus.thanos.ingress.apiVersion Force Ingress API version (automatically detected if not set)
+      ##
+      apiVersion: ""
+      ## @param prometheus.thanos.ingress.hostname Default host for the ingress record
+      ##
+      hostname: thanos.prometheus.local
+      ## @param prometheus.thanos.ingress.path Default path for the ingress record
+      ## NOTE: You may need to set this to '/*' in order to use this with ALB ingress controllers
+      ##
+      path: /
+      ## @param prometheus.thanos.ingress.annotations Additional annotations for the Ingress resource. To enable certificate autogeneration, place here your cert-manager annotations.
+      ## For a full list of possible ingress annotations, please see
+      ## ref: https://github.com/kubernetes/ingress-nginx/blob/master/docs/user-guide/nginx-configuration/annotations.md
+      ## Use this parameter to set the required annotations for cert-manager, see
+      ## ref: https://cert-manager.io/docs/usage/ingress/#supported-annotations
+      ##
+      ## Examples:
+      ## kubernetes.io/ingress.class: nginx
+      ## cert-manager.io/cluster-issuer: cluster-issuer-name
+      ##
+      annotations: {}
+      ## @param prometheus.thanos.ingress.ingressClassName IngressClass that will be be used to implement the Ingress (Kubernetes 1.18+)
+      ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster .
+      ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/
+      ##
+      ingressClassName: ""
+      ## @param prometheus.thanos.ingress.tls Enable TLS configuration for the host defined at `ingress.hostname` parameter
+      ## TLS certificates will be retrieved from a TLS secret with name: `{{- printf "%s-tls" .Values.ingress.hostname }}`
+      ## You can:
+      ##   - Use the `ingress.secrets` parameter to create this TLS secret
+      ##   - Relay on cert-manager to create it by setting `ingress.certManager=true`
+      ##   - Relay on Helm to create self-signed certificates by setting `ingress.selfSigned=true`
+      ##
+      tls: false
+      ## @param prometheus.thanos.ingress.selfSigned Create a TLS secret for this ingress record using self-signed certificates generated by Helm
+      ##
+      selfSigned: false
+      ## @param prometheus.thanos.ingress.extraHosts An array with additional hostname(s) to be covered with the ingress record
+      ## e.g:
+      ## extraHosts:
+      ##   - name: thanos.prometheus.local
+      ##     path: /
+      ##
+      extraHosts: []
+      ## @param prometheus.thanos.ingress.extraPaths An array with additional arbitrary paths that may need to be added to the ingress under the main host
+      ## e.g:
+      ## extraPaths:
+      ## - path: /*
+      ##   backend:
+      ##     serviceName: ssl-redirect
+      ##     servicePort: use-annotation
+      ##
+      extraPaths: []
+      ## @param prometheus.thanos.ingress.extraTls TLS configuration for additional hostname(s) to be covered with this ingress record
+      ## ref: https://kubernetes.io/docs/concepts/services-networking/ingress/#tls
+      ## e.g:
+      ## extraTls:
+      ## - hosts:
+      ##     - thanos.prometheus.local
+      ##   secretName: thanos.prometheus.local-tls
+      ##
+      extraTls: []
+      ## @param prometheus.thanos.ingress.secrets Custom TLS certificates as secrets
+      ## NOTE: 'key' and 'certificate' are expected in PEM format
+      ## NOTE: 'name' should line up with a 'secretName' set further up
+      ## If it is not set and you're using cert-manager, this is unneeded, as it will create a secret for you with valid certificates
+      ## If it is not set and you're NOT using cert-manager either, self-signed certificates will be created valid for 365 days
+      ## It is also possible to create and manage the certificates outside of this helm chart
+      ## Please see README.md for more information
+      ## e.g:
+      ## secrets:
+      ##   - name: thanos.prometheus.local-tls
+      ##     key: |-
+      ##       -----BEGIN RSA PRIVATE KEY-----
+      ##       ...
+      ##       -----END RSA PRIVATE KEY-----
+      ##     certificate: |-
+      ##       -----BEGIN CERTIFICATE-----
+      ##       ...
+      ##       -----END CERTIFICATE-----
+      ##
+      secrets: []
+      ## @param prometheus.thanos.ingress.extraRules The list of additional rules to be added to this ingress record. Evaluated as a template
+      ## Useful when looking for additional customization, such as using different backend
+      ##
+      extraRules: []
+
+network:
+  prometheus:
+    ingress:
+      public: true
+      classes:
+        namespace: "nginx"
+        cluster: "nginx-cluster"
+      annotations:
+        nginx.ingress.kubernetes.io/rewrite-target: /
+        nginx.ingress.kubernetes.io/affinity: cookie
+        nginx.ingress.kubernetes.io/session-cookie-name: kube-ingress-session-prometheus
+        nginx.ingress.kubernetes.io/session-cookie-hash: sha1
+        nginx.ingress.kubernetes.io/session-cookie-expires: "600"
+        nginx.ingress.kubernetes.io/session-cookie-max-age: "600"
+    node_port:
+      enabled: false
+      port: 30900
+
+network_policy:
+  prometheus:
+    ingress:
+      - {}
+    egress:
+      - {}
+
+secrets:
+  oci_image_registry:
+    prometheus: prometheus-oci-image-registry-key
+  tls:
+    monitoring:
+      prometheus:
+        public: prometheus-tls-public
+        internal: prometheus-tls-api
+
+tls_configs:
+  # If client certificates are required to connect to metrics endpoints, they
+  # can be configured here. They will be mounted in the pod under /tls_configs
+  # and can be referenced in scrape configs.
+  # The filenames will be the key and subkey concatenanted with a ".", e.g.:
+  #   /tls_configs/kubernetes-etcd.ca.pem
+  #   /tls_configs/kubernetes-etcd.crt.pem
+  #   /tls_configs/kubernetes-etcd.key.pem
+  # From the following:
+  # kubernetes-etcd:
+  #   ca.pem: |
+  #     -----BEGIN CERTIFICATE-----
+  #     -----END CERTIFICATE-----
+  #   crt.pem: |
+  #     -----BEGIN CERTIFICATE-----
+  #     -----END CERTIFICATE-----
+  #   key.pem: |
+  #     -----BEGIN RSA PRIVATE KEY-----
+  #     -----END RSA PRIVATE KEY-----
+
+storage:
+  enabled: true
+  pvc:
+    name: prometheus-pvc
+    access_mode: ["ReadWriteOnce"]
+  requests:
+    storage: 5Gi
+  storage_class: general
+
+manifests:
+  certificates: false
+  configmap_bin: true
+  configmap_etc: true
+  ingress: true
+  helm_tests: true
+  job_image_repo_sync: true
+  network_policy: true
+  secret_ingress_tls: true
+  secret_prometheus: true
+  secret_registry: true
+  service_ingress: true
+  service: true
+  statefulset_prometheus: true
+
+conf:
+  httpd: |
+    ServerRoot "/usr/local/apache2"
+
+    Listen 80
+
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule authn_file_module modules/mod_authn_file.so
+    LoadModule authn_core_module modules/mod_authn_core.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    LoadModule access_compat_module modules/mod_access_compat.so
+    LoadModule auth_basic_module modules/mod_auth_basic.so
+    LoadModule ldap_module modules/mod_ldap.so
+    LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+    LoadModule reqtimeout_module modules/mod_reqtimeout.so
+    LoadModule filter_module modules/mod_filter.so
+    LoadModule proxy_html_module modules/mod_proxy_html.so
+    LoadModule log_config_module modules/mod_log_config.so
+    LoadModule env_module modules/mod_env.so
+    LoadModule headers_module modules/mod_headers.so
+    LoadModule setenvif_module modules/mod_setenvif.so
+    LoadModule version_module modules/mod_version.so
+    LoadModule proxy_module modules/mod_proxy.so
+    LoadModule proxy_connect_module modules/mod_proxy_connect.so
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+    LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+    LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+    LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+    LoadModule unixd_module modules/mod_unixd.so
+    LoadModule status_module modules/mod_status.so
+    LoadModule autoindex_module modules/mod_autoindex.so
+
+    <IfModule unixd_module>
+    User daemon
+    Group daemon
+    </IfModule>
+
+    <Directory />
+        AllowOverride none
+        Require all denied
+    </Directory>
+
+    <Files ".ht*">
+        Require all denied
+    </Files>
+
+    ErrorLog /dev/stderr
+
+    LogLevel warn
+
+    <IfModule log_config_module>
+        LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+        LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+        <IfModule logio_module>
+          LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+        </IfModule>
+
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout common
+        CustomLog /dev/stdout combined
+        CustomLog /dev/stdout proxy env=forwarded
+    </IfModule>
+
+    <Directory "/usr/local/apache2/cgi-bin">
+        AllowOverride None
+        Options None
+        Require all granted
+    </Directory>
+
+    <IfModule headers_module>
+        RequestHeader unset Proxy early
+    </IfModule>
+
+    <IfModule proxy_html_module>
+    Include conf/extra/proxy-html.conf
+    </IfModule>
+
+    <VirtualHost *:80>
+      # Expose metrics to all users, as this is not sensitive information and
+      # circumvents the inability of Prometheus to interpolate environment vars
+      # in its configuration file
+      <Location /metrics>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          Satisfy Any
+          Allow from all
+      </Location>
+      # Expose the /federate endpoint to all users, as this is also not
+      # sensitive information and circumvents the inability of Prometheus to
+      # interpolate environment vars in its configuration file
+      <Location /federate>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          Satisfy Any
+          Allow from all
+      </Location>
+      # Restrict general user (LDAP) access to the /graph endpoint, as general trusted
+      # users should only be able to query Prometheus for metrics and not have access
+      # to information like targets, configuration, flags or build info for Prometheus
+      <Location />
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file ldap
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          AuthLDAPBindDN {{ .Values.endpoints.ldap.auth.admin.bind }}
+          AuthLDAPBindPassword {{ .Values.endpoints.ldap.auth.admin.password }}
+          AuthLDAPURL {{ tuple "ldap" "default" "ldap" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | quote }}
+          Require valid-user
+      </Location>
+      <Location /graph>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/graph
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/graph
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file ldap
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          AuthLDAPBindDN {{ .Values.endpoints.ldap.auth.admin.bind }}
+          AuthLDAPBindPassword {{ .Values.endpoints.ldap.auth.admin.password }}
+          AuthLDAPURL {{ tuple "ldap" "default" "ldap" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | quote }}
+          Require valid-user
+      </Location>
+      # Restrict access to the /config (dashboard) and /api/v1/status/config (http) endpoints
+      # to the admin user
+      <Location /config>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/config
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/config
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/status/config>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/config
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/config
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /flags (dashboard) and /api/v1/status/flags (http) endpoints
+      # to the admin user
+      <Location /flags>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/flags
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/flags
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/status/flags>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/flags
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/flags
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /status (dashboard) endpoint to the admin user
+      <Location /status>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/status
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/status
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /rules (dashboard) endpoint to the admin user
+      <Location /rules>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/rules
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/rules
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /targets (dashboard) and /api/v1/targets (http) endpoints
+      # to the admin user
+      <Location /targets>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/targets
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/targets
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/targets>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/targets
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/targets
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /api/v1/admin/tsdb/ endpoints (http) to the admin user.
+      # These endpoints are disabled by default, but are included here to ensure only
+      # an admin user has access to these endpoints when enabled
+      <Location /api/v1/admin/tsdb/>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/admin/tsdb/
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/admin/tsdb/
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+    </VirtualHost>
+  prometheus:
+    # Consumed by a prometheus helper function to generate the command line flags
+    # for configuring the prometheus service
+    command_line_flags:
+      log.level: info
+      query.max_concurrency: 20
+      query.timeout: 2m
+      storage.tsdb.path: /var/lib/prometheus/data
+      storage.tsdb.retention.time: 7d
+      # NOTE(srwilkers): These settings default to false, but they are
+      # exposed here to allow enabling if desired. Please note the security
+      # impacts of enabling these flags. More information regarding the impacts
+      # can be found here: https://prometheus.io/docs/operating/security/
+      #
+      # If set to true, all administrative functionality is exposed via the http
+      # /api/*/admin/ path
+      web.enable_admin_api: false
+      # If set to true, allows for http reloads and shutdown of Prometheus
+      web.enable_lifecycle: false
+    scrape_configs:
+      template: |
+        {{- $promHost := tuple "monitoring" "public" . | include "helm-toolkit.endpoints.hostname_fqdn_endpoint_lookup" }}
+        {{- if not (empty .Values.conf.prometheus.rules)}}
+        rule_files:
+        {{- $rulesKeys := keys .Values.conf.prometheus.rules -}}
+        {{- range $rule := $rulesKeys }}
+          {{ printf "- /etc/config/rules/%s.rules" $rule }}
+        {{- end }}
+        {{- end }}
+        global:
+          scrape_interval: 60s
+          evaluation_interval: 60s
+          external_labels:
+            prometheus_host: {{$promHost}}
+        scrape_configs:
+          - job_name: kubelet
+            scheme: https
+            # This TLS & bearer token file config is used to connect to the actual scrape
+            # endpoints for cluster components. This is separate to discovery auth
+            # configuration because discovery & scraping are two separate concerns in
+            # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+            # the cluster. Otherwise, more config options have to be provided within the
+            # <kubernetes_sd_config>.
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            kubernetes_sd_configs:
+            - role: node
+            scrape_interval: 45s
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels:
+                - __meta_kubernetes_node_name
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/${1}/proxy/metrics
+            - source_labels:
+                - __meta_kubernetes_node_name
+              action: replace
+              target_label: kubernetes_io_hostname
+            # Scrape config for Kubelet cAdvisor.
+            #
+            # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
+            # (those whose names begin with 'container_') have been removed from the
+            # Kubelet metrics endpoint.  This job scrapes the cAdvisor endpoint to
+            # retrieve those metrics.
+            #
+            # In Kubernetes 1.7.0-1.7.2, these metrics are only exposed on the cAdvisor
+            # HTTP endpoint; use "replacement: /api/v1/nodes/${1}:4194/proxy/metrics"
+            # in that case (and ensure cAdvisor's HTTP server hasn't been disabled with
+            # the --cadvisor-port=0 Kubelet flag).
+            #
+            # This job is not necessary and should be removed in Kubernetes 1.6 and
+            # earlier versions, or it will cause the metrics to be scraped twice.
+          - job_name: 'kubernetes-cadvisor'
+
+            # Default to scraping over https. If required, just disable this or change to
+            # `http`.
+            scheme: https
+
+            # This TLS & bearer token file config is used to connect to the actual scrape
+            # endpoints for cluster components. This is separate to discovery auth
+            # configuration because discovery & scraping are two separate concerns in
+            # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+            # the cluster. Otherwise, more config options have to be provided within the
+            # <kubernetes_sd_config>.
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+
+            kubernetes_sd_configs:
+            - role: node
+
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_node_label_(.+)
+            - target_label: __address__
+              replacement: kubernetes.default.svc:443
+            - source_labels:
+                - __meta_kubernetes_node_name
+              regex: (.+)
+              target_label: __metrics_path__
+              replacement: /api/v1/nodes/${1}/proxy/metrics/cadvisor
+            metric_relabel_configs:
+            - source_labels:
+                - __name__
+              regex: 'container_network_tcp_usage_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_tasks_state'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_udp_usage_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_failures_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_cpu_load_average_10s'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_cpu_system_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_cpu_user_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_inodes_free'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_inodes_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_io_current'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_io_time_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_io_time_weighted_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_read_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_reads_merged_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_reads_merged_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_reads_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_sector_reads_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_sector_writes_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_write_seconds_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_writes_bytes_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_writes_merged_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_fs_writes_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_last_seen'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_cache'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_failcnt'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_max_usage_bytes'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_rss'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_swap'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_memory_usage_bytes'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_receive_errors_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_receive_packets_dropped_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_receive_packets_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_transmit_errors_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_transmit_packets_dropped_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_network_transmit_packets_total'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_spec_cpu_period'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_spec_cpu_shares'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_spec_memory_limit_bytes'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_spec_memory_reservation_limit_bytes'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_spec_memory_swap_limit_bytes'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'container_start_time_seconds'
+              action: drop
+            # Scrape config for API servers.
+            #
+            # Kubernetes exposes API servers as endpoints to the default/kubernetes
+            # service so this uses `endpoints` role and uses relabelling to only keep
+            # the endpoints associated with the default/kubernetes service using the
+            # default named port `https`. This works for single API server deployments as
+            # well as HA API server deployments.
+          - job_name: 'apiserver'
+            kubernetes_sd_configs:
+            - role: endpoints
+            scrape_interval: 45s
+            # Default to scraping over https. If required, just disable this or change to
+            # `http`.
+            scheme: https
+            # This TLS & bearer token file config is used to connect to the actual scrape
+            # endpoints for cluster components. This is separate to discovery auth
+            # configuration because discovery & scraping are two separate concerns in
+            # Prometheus. The discovery auth config is automatic if Prometheus runs inside
+            # the cluster. Otherwise, more config options have to be provided within the
+            # <kubernetes_sd_config>.
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+              # If your node certificates are self-signed or use a different CA to the
+              # master CA, then disable certificate verification below. Note that
+              # certificate verification is an integral part of a secure infrastructure
+              # so this should only be disabled in a controlled environment. You can
+              # disable certificate verification by uncommenting the line below.
+              #
+              # insecure_skip_verify: true
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            # Keep only the default/kubernetes service endpoints for the https port. This
+            # will add targets for each API server which Kubernetes adds an endpoint to
+            # the default/kubernetes service.
+            relabel_configs:
+            - source_labels:
+                - __meta_kubernetes_namespace
+                - __meta_kubernetes_service_name
+                - __meta_kubernetes_endpoint_port_name
+              action: keep
+              regex: default;kubernetes;https
+            metric_relabel_configs:
+            - source_labels:
+                - __name__
+              regex: 'apiserver_admission_controller_admission_latencies_seconds_bucket'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'rest_client_request_latency_seconds_bucket'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'apiserver_response_sizes_bucket'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'apiserver_admission_step_admission_latencies_seconds_bucket'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'apiserver_admission_controller_admission_latencies_seconds_count'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'apiserver_admission_controller_admission_latencies_seconds_sum'
+              action: drop
+            - source_labels:
+                - __name__
+              regex: 'apiserver_request_latencies_summary'
+              action: drop
+          # Scrape config for service endpoints.
+          #
+          # The relabeling allows the actual service scrape endpoint to be configured
+          # via the following annotations:
+          #
+          # * `prometheus.io/scrape`: Only scrape services that have a value of `true`
+          # * `prometheus.io/scheme`: If the metrics endpoint is secured then you will need
+          # to set this to `https` & most likely set the `tls_config` of the scrape config.
+          # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+          # * `prometheus.io/port`: If the metrics are exposed on a different port to the
+          # service then set this appropriately.
+          - job_name: 'openstack-exporter'
+            kubernetes_sd_configs:
+            - role: endpoints
+            scrape_interval: 60s
+            relabel_configs:
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: keep
+              regex: "openstack-metrics"
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+              action: keep
+              regex: true
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              action: replace
+              target_label: __scheme__
+              regex: (https?)
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              action: replace
+              target_label: __address__
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_namespace
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: replace
+              target_label: instance
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: replace
+              target_label: kubernetes_name
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+              replacement: ${1}
+          - job_name: 'node-exporter'
+            kubernetes_sd_configs:
+            - role: endpoints
+            scrape_interval: 60s
+            relabel_configs:
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: keep
+              regex: 'node-exporter'
+            - source_labels:
+                - __meta_kubernetes_pod_node_name
+              action: replace
+              target_label: hostname
+          - job_name: 'kubernetes-service-endpoints'
+            kubernetes_sd_configs:
+            - role: endpoints
+            scrape_interval: 60s
+            relabel_configs:
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: drop
+              regex: '(openstack-metrics|prom-metrics|ceph-mgr|node-exporter)'
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scrape
+              action: keep
+              regex: true
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_scheme
+              action: replace
+              target_label: __scheme__
+              regex: (https?)
+            - source_labels:
+                - __meta_kubernetes_service_annotation_prometheus_io_path
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels:
+                - __address__
+                - __meta_kubernetes_service_annotation_prometheus_io_port
+              action: replace
+              target_label: __address__
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - source_labels:
+                - __meta_kubernetes_namespace
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels:
+                - __meta_kubernetes_service_name
+              action: replace
+              target_label: kubernetes_name
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+              replacement: ${1}
+          # Example scrape config for pods
+          #
+          # The relabeling allows the actual pod scrape endpoint to be configured via the
+          # following annotations:
+          #
+          # * `prometheus.io/scrape`: Only scrape pods that have a value of `true`
+          # * `prometheus.io/path`: If the metrics path is not `/metrics` override this.
+          # * `prometheus.io/port`: Scrape the pod on the indicated port instead of the
+          # pod's declared ports (default is a port-free target if none are declared).
+          - job_name: 'kubernetes-pods'
+            kubernetes_sd_configs:
+            - role: pod
+            relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_scrape]
+              action: keep
+              regex: true
+            - source_labels: [__meta_kubernetes_pod_annotation_prometheus_io_path]
+              action: replace
+              target_label: __metrics_path__
+              regex: (.+)
+            - source_labels: [__address__, __meta_kubernetes_pod_annotation_prometheus_io_port]
+              action: replace
+              regex: ([^:]+)(?::\d+)?;(\d+)
+              replacement: $1:$2
+              target_label: __address__
+            - action: labelmap
+              regex: __meta_kubernetes_pod_label_(.+)
+            - source_labels: [__meta_kubernetes_namespace]
+              action: replace
+              target_label: kubernetes_namespace
+            - source_labels: [__meta_kubernetes_pod_name]
+              action: replace
+              target_label: kubernetes_pod_name
+          - job_name: calico-etcd
+            kubernetes_sd_configs:
+            - role: service
+            scrape_interval: 20s
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: keep
+              source_labels:
+                - __meta_kubernetes_service_name
+              regex: "calico-etcd"
+            - action: keep
+              source_labels:
+                - __meta_kubernetes_namespace
+              regex: kube-system
+              target_label: namespace
+            - source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: service
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+              replacement: ${1}
+            - source_labels:
+                - __meta_kubernetes_service_label
+              target_label: job
+              regex: calico-etcd
+              replacement: ${1}
+            - target_label: endpoint
+              replacement: "calico-etcd"
+          - job_name: ceph-mgr
+            kubernetes_sd_configs:
+            - role: service
+            scrape_interval: 20s
+            relabel_configs:
+            - action: labelmap
+              regex: __meta_kubernetes_service_label_(.+)
+            - action: keep
+              source_labels:
+                - __meta_kubernetes_service_name
+              regex: "ceph-mgr"
+            - source_labels:
+                - __meta_kubernetes_service_port_name
+              action: drop
+              regex: 'ceph-mgr'
+            - action: keep
+              source_labels:
+                - __meta_kubernetes_namespace
+              regex: ceph
+              target_label: namespace
+            - source_labels:
+                - __meta_kubernetes_pod_name
+              target_label: pod
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: service
+            - source_labels:
+                - __meta_kubernetes_service_name
+              target_label: job
+              replacement: ${1}
+            - source_labels:
+                - __meta_kubernetes_service_label
+              target_label: job
+              regex: ceph-mgr
+              replacement: ${1}
+            - target_label: endpoint
+              replacement: "ceph-mgr"
+        alerting:
+          alertmanagers:
+          - kubernetes_sd_configs:
+              - role: pod
+            tls_config:
+              ca_file: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+            bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
+            relabel_configs:
+            - source_labels: [__meta_kubernetes_pod_label_application]
+              regex: prometheus-alertmanager
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              regex: alerts-api
+              action: keep
+            - source_labels: [__meta_kubernetes_pod_container_port_name]
+              regex: peer-mesh
+              action: drop
+    rules: []
+...

--- a/prometheus/values_overrides/alertmanager.yaml
+++ b/prometheus/values_overrides/alertmanager.yaml
@@ -1,0 +1,33 @@
+---
+conf:
+  prometheus:
+    rules:
+      alertmanager:
+        groups:
+        - name: alertmanager.rules
+          rules:
+          - alert: AlertmanagerConfigInconsistent
+            expr: count_values("config_hash", alertmanager_config_hash) BY (service) / ON(service) GROUP_LEFT() label_replace(prometheus_operator_alertmanager_spec_replicas, "service", "alertmanager-$1", "alertmanager", "(.*)") != 1
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              description: The configuration of the instances of the Alertmanager cluster `{{$labels.service}}` are out of sync.
+              summary: Alertmanager configurations are inconsistent
+          - alert: AlertmanagerDownOrMissing
+            expr: label_replace(prometheus_operator_alertmanager_spec_replicas, "job", "alertmanager-$1", "alertmanager", "(.*)") / ON(job) GROUP_RIGHT() sum(up) BY (job) != 1
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: An unexpected number of Alertmanagers are scraped or Alertmanagers disappeared from discovery.
+              summary: Alertmanager down or not discovered
+          - alert: FailedReload
+            expr: alertmanager_config_last_reload_successful == 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: Reloading Alertmanager's configuration has failed for {{ $labels.namespace }}/{{ $labels.pod }}.
+              summary: Alertmanager configuration reload has failed
+...

--- a/prometheus/values_overrides/apparmor.yaml
+++ b/prometheus/values_overrides/apparmor.yaml
@@ -1,0 +1,13 @@
+---
+pod:
+  mandatory_access_control:
+    type: apparmor
+    prometheus:
+      prometheus: runtime/default
+      prometheus-perms: runtime/default
+      apache-proxy: runtime/default
+      init: runtime/default
+    prometheus-test:
+      prometheus-helm-tests: runtime/default
+      init: runtime/default
+...

--- a/prometheus/values_overrides/ceph.yaml
+++ b/prometheus/values_overrides/ceph.yaml
@@ -1,0 +1,84 @@
+---
+conf:
+  prometheus:
+    rules:
+      ceph:
+        groups:
+        - name: ceph.recording_rules
+          rules:
+          - record: ceph_cluster_usage_percent
+            expr: 100 * (ceph_cluster_total_used_bytes / ceph_cluster_total_bytes)
+          - record: ceph_placement_group_degrade_percent
+            expr: 100 * (ceph_pg_degraded / ceph_pg_total)
+          - record: ceph_osd_down_percent
+            expr: 100 * (count(ceph_osd_up == 0) / count(ceph_osd_metadata))
+          - record: ceph_osd_out_percent
+            expr: 100 * (count(ceph_osd_in == 0) / count(ceph_osd_metadata))
+        - name: ceph.alerting_rules
+          rules:
+          - alert: prom_exporter_ceph_unavailable
+            expr: absent(ceph_health_status)
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: Ceph exporter is not collecting metrics or is not available for past 10 minutes
+              title: Ceph exporter is not collecting metrics or is not available
+          - alert: no_active_ceph_mgr
+            expr: avg_over_time(up{job="ceph-mgr"}[5m]) == 0
+            labels:
+              severity: warning
+            annotations:
+              description: 'no ceph active mgr is present or all ceph mgr are down'
+              summary: 'no ceph active mgt is present'
+          - alert: ceph_monitor_quorum_low
+            expr: ceph_mon_quorum_count < 3
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'ceph monitor quorum has been less than 3 for more than 5 minutes'
+              summary: 'ceph high availability is at risk'
+          - alert: ceph_monitor_quorum_absent
+            expr: absent(avg_over_time(ceph_mon_quorum_status[5m]))
+            labels:
+              severity: page
+            annotations:
+              description: 'ceph monitor quorum has been gone for more than 5 minutes'
+              summary: 'ceph high availability is at risk'
+          - alert: ceph_cluster_usage_high
+            expr: avg_over_time(ceph_cluster_usage_percent[5m]) > 80
+            labels:
+              severity: page
+            annotations:
+              description: 'ceph cluster capacity usage more than 80 percent'
+              summary: 'ceph cluster usage is more than 80 percent'
+          - alert: ceph_placement_group_degrade_pct_high
+            expr: avg_over_time(ceph_placement_group_degrade_percent[5m]) > 80
+            labels:
+              severity: critical
+            annotations:
+              description: 'ceph placement group degradation is more than 80 percent'
+              summary: 'ceph placement groups degraded'
+          - alert: ceph_osd_down_pct_high
+            expr: avg_over_time(ceph_osd_down_percent[5m]) > 80
+            labels:
+              severity: critical
+            annotations:
+              description: 'ceph OSDs down percent is more than 80 percent'
+              summary: 'ceph OSDs down percent is high'
+          - alert: ceph_osd_down
+            expr: avg_over_time(ceph_osd_up[5m]) == 0
+            labels:
+              severity: critical
+            annotations:
+              description: 'ceph OSD {{ $labels.ceph_daemon }} is down in instance {{ $labels.instance }}.'
+              summary: 'ceph OSD {{ $labels.ceph_daemon }} is down in instance {{ $labels.instance }}.'
+          - alert: ceph_osd_out
+            expr: avg_over_time(ceph_osd_in[5m]) == 0
+            labels:
+              severity: page
+            annotations:
+              description: 'ceph OSD {{ $labels.ceph_daemon }} is out in instance {{ $labels.instance }}.'
+              summary: 'ceph OSD {{ $labels.ceph_daemon }} is out in instance {{ $labels.instance }}.'
+...

--- a/prometheus/values_overrides/elasticsearch.yaml
+++ b/prometheus/values_overrides/elasticsearch.yaml
@@ -1,0 +1,101 @@
+---
+conf:
+  prometheus:
+    rules:
+      elasticsearch:
+        groups:
+        - name: elasticsearch.alerting_rules
+          rules:
+          - alert: prom_exporter_elasticsearch_unavailable
+            expr: avg_over_time(up{job="elasticsearch-exporter"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: Elasticsearch exporter is not collecting metrics or is not available for past 10 minutes
+              title: Elasticsearch exporter is not collecting metrics or is not available
+          - alert: es_high_process_open_files_count
+            expr: sum(elasticsearch_process_open_files_count) by (host) > 64000
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch at {{ $labels.host }} has more than 64000 process open file count.'
+              summary: 'Elasticsearch has a very high process open file count.'
+          - alert: es_high_process_cpu_percent
+            expr: elasticsearch_process_cpu_percent > 95
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch at {{ $labels.instance }} has high process cpu percent of {{ $value }}.'
+              summary: 'Elasticsearch process cpu usage is more than 95 percent.'
+          - alert: es_fs_usage_high
+            expr: (100 * (elasticsearch_filesystem_data_size_bytes - elasticsearch_filesystem_data_free_bytes) / elasticsearch_filesystem_data_size_bytes) > 80
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch at {{ $labels.instance }} has filesystem usage of {{ $value }}.'
+              summary: 'Elasticsearch filesystem usage is high.'
+          - alert: es_unassigned_shards
+            expr: elasticsearch_cluster_health_unassigned_shards > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch has {{ $value }} unassigned shards.'
+              summary: 'Elasticsearch has unassigned shards and hence a unhealthy cluster state.'
+          - alert: es_cluster_health_timed_out
+            expr: elasticsearch_cluster_health_timed_out > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch cluster health status call timedout {{ $value }} times.'
+              summary: 'Elasticsearch cluster health status calls are timing out.'
+          - alert: es_cluster_health_status_alert
+            expr: (sum(elasticsearch_cluster_health_status{color="green"})*2)+sum(elasticsearch_cluster_health_status{color="yellow"}) < 2
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Elasticsearch cluster health status is {{ $value }}, not 2 (green). One or more shards or replicas are unallocated.'
+              summary: 'Elasticsearch cluster health status is not green.'
+          - alert: es_cluster_health_too_few_nodes_running
+            expr: elasticsearch_cluster_health_number_of_nodes < 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'There are only {{$value}} < 3 ElasticSearch nodes running'
+              summary: 'ElasticSearch running on less than 3 nodes'
+          - alert: es_cluster_health_too_few_data_nodes_running
+            expr: elasticsearch_cluster_health_number_of_data_nodes < 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'There are only {{$value}} < 3 ElasticSearch data nodes running'
+              summary: 'ElasticSearch running on less than 3 data nodes'
+          - alert: es_cluster_health_too_few_data_nodes_running
+            expr: elasticsearch_cluster_health_number_of_data_nodes < 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'There are only {{$value}} < 3 ElasticSearch data nodes running'
+              summary: 'ElasticSearch running on less than 3 data nodes'
+      fluentd:
+        groups:
+        - name: fluentd.alerting_rules
+          rules:
+          - alert: prom_exporter_fluentd_unavailable
+            expr: avg_over_time(up{job="fluentd-daemonset-exporter"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: Fluentd exporter is not collecting metrics or is not available for past 10 minutes
+              title: Fluentd exporter is not collecting metrics or is not available
+...

--- a/prometheus/values_overrides/kubernetes.yaml
+++ b/prometheus/values_overrides/kubernetes.yaml
@@ -1,0 +1,381 @@
+---
+conf:
+  prometheus:
+    rules:
+      kubernetes:
+        groups:
+        - name: calico.rules
+          rules:
+          - alert: prom_exporter_calico_unavailable
+            expr: avg_over_time(up{job="kubernetes-pods",application="calico"}[5m]) == 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: Calico exporter is not collecting metrics or is not available for past 10 minutes
+              title: Calico exporter is not collecting metrics or is not available
+          - alert: calico_datapane_failures_high_1h
+            expr: absent(felix_int_dataplane_failures) OR increase(felix_int_dataplane_failures[1h]) > 5
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen {{ $value }} dataplane failures within the last hour'
+              summary: 'A high number of dataplane failures within Felix are happening'
+          - alert: calico_datapane_address_msg_batch_size_high_5m
+            expr: absent(felix_int_dataplane_addr_msg_batch_size_sum) OR absent(felix_int_dataplane_addr_msg_batch_size_count) OR (felix_int_dataplane_addr_msg_batch_size_sum/felix_int_dataplane_addr_msg_batch_size_count) > 5
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen a high value of {{ $value }} dataplane address message batch size'
+              summary: 'Felix address message batch size is higher'
+          - alert: calico_datapane_iface_msg_batch_size_high_5m
+            expr: absent(felix_int_dataplane_iface_msg_batch_size_sum) OR absent(felix_int_dataplane_iface_msg_batch_size_count) OR (felix_int_dataplane_iface_msg_batch_size_sum/felix_int_dataplane_iface_msg_batch_size_count) > 5
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen a high value of {{ $value }} dataplane interface message batch size'
+              summary: 'Felix interface message batch size is higher'
+          - alert: calico_ipset_errors_high_1h
+            expr: absent(felix_ipset_errors) OR increase(felix_ipset_errors[1h]) > 5
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen {{ $value }} ipset errors within the last hour'
+              summary: 'A high number of ipset errors within Felix are happening'
+          - alert: calico_iptable_save_errors_high_1h
+            expr: absent(felix_iptables_save_errors) OR increase(felix_iptables_save_errors[1h]) > 5
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen {{ $value }} iptable save errors within the last hour'
+              summary: 'A high number of iptable save errors within Felix are happening'
+          - alert: calico_iptable_restore_errors_high_1h
+            expr: absent(felix_iptables_restore_errors) OR increase(felix_iptables_restore_errors[1h]) > 5
+            labels:
+              severity: page
+            annotations:
+              description: 'Felix instance {{ $labels.instance }} has seen {{ $value }} iptable restore errors within the last hour'
+              summary: 'A high number of iptable restore errors within Felix are happening'
+        - name: etcd3.rules
+          rules:
+          - alert: etcd_InsufficientMembers
+            expr: count(up{job="etcd"} == 0) > (count(up{job="etcd"}) / 2 - 1)
+            for: 3m
+            labels:
+              severity: critical
+            annotations:
+              description: If one more etcd member goes down the cluster will be unavailable
+              summary: etcd cluster insufficient members
+          - alert: etcd_NoLeader
+            expr: etcd_server_has_leader{job="etcd"} == 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: etcd member {{ $labels.instance }} has no leader
+              summary: etcd member has no leader
+          - alert: etcd_HighNumberOfLeaderChanges
+            expr: increase(etcd_server_leader_changes_seen_total{job="etcd"}[1h]) > 3
+            labels:
+              severity: warning
+            annotations:
+              description: etcd instance {{ $labels.instance }} has seen {{ $value }} leader changes within the last hour
+              summary: a high number of leader changes within the etcd cluster are happening
+          - alert: etcd_HighNumberOfFailedGRPCRequests
+            expr: sum(rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) BY (grpc_method) / sum(rate(etcd_grpc_total{job="etcd"}[5m])) BY (grpc_method) > 0.01
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+              summary: a high number of gRPC requests are failing
+          - alert: etcd_HighNumberOfFailedGRPCRequests
+            expr: sum(rate(etcd_grpc_requests_failed_total{job="etcd"}[5m])) BY (grpc_method) / sum(rate(etcd_grpc_total{job="etcd"}[5m])) BY (grpc_method) > 0.05
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              description: '{{ $value }}% of requests for {{ $labels.grpc_method }} failed on etcd instance {{ $labels.instance }}'
+              summary: a high number of gRPC requests are failing
+          - alert: etcd_GRPCRequestsSlow
+            expr: histogram_quantile(0.99, rate(etcd_grpc_unary_requests_duration_seconds_bucket[5m])) > 0.15
+            for: 10m
+            labels:
+              severity: critical
+            annotations:
+              description: on etcd instance {{ $labels.instance }} gRPC requests to {{ $labels.grpc_method }} are slow
+              summary: slow gRPC requests
+          - alert: etcd_HighNumberOfFailedHTTPRequests
+            expr: sum(rate(etcd_http_failed_total{job="etcd"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="etcd"}[5m])) BY (method) > 0.01
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}'
+              summary: a high number of HTTP requests are failing
+          - alert: etcd_HighNumberOfFailedHTTPRequests
+            expr: sum(rate(etcd_http_failed_total{job="etcd"}[5m])) BY (method) / sum(rate(etcd_http_received_total{job="etcd"}[5m])) BY (method) > 0.05
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              description: '{{ $value }}% of requests for {{ $labels.method }} failed on etcd instance {{ $labels.instance }}'
+              summary: a high number of HTTP requests are failing
+          - alert: etcd_HTTPRequestsSlow
+            expr: histogram_quantile(0.99, rate(etcd_http_successful_duration_seconds_bucket[5m])) > 0.15
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: on etcd instance {{ $labels.instance }} HTTP requests to {{ $labels.method }} are slow
+              summary: slow HTTP requests
+          - alert: etcd_EtcdMemberCommunicationSlow
+            expr: histogram_quantile(0.99, rate(etcd_network_member_round_trip_time_seconds_bucket[5m])) > 0.15
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: etcd instance {{ $labels.instance }} member communication with {{ $labels.To }} is slow
+              summary: etcd member communication is slow
+          - alert: etcd_HighNumberOfFailedProposals
+            expr: increase(etcd_server_proposals_failed_total{job="etcd"}[1h]) > 5
+            labels:
+              severity: warning
+            annotations:
+              description: etcd instance {{ $labels.instance }} has seen {{ $value }} proposal failures within the last hour
+              summary: a high number of proposals within the etcd cluster are failing
+          - alert: etcd_HighFsyncDurations
+            expr: histogram_quantile(0.99, rate(etcd_disk_wal_fsync_duration_seconds_bucket[5m])) > 0.5
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: etcd instance {{ $labels.instance }} fync durations are high
+              summary: high fsync durations
+          - alert: etcd_HighCommitDurations
+            expr: histogram_quantile(0.99, rate(etcd_disk_backend_commit_duration_seconds_bucket[5m])) > 0.25
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: etcd instance {{ $labels.instance }} commit durations are high
+              summary: high commit durations
+        - name: kubelet.rules
+          rules:
+          - alert: K8SNodeNotReady
+            expr: kube_node_status_condition{condition="Ready", status="unknown"} == 1 or kube_node_status_condition{condition="Ready", status="false"} == 1
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: The Kubelet on {{ $labels.node }} has not checked in with the API, or has set itself to NotReady, for more than a minute
+              summary: '{{ $labels.node }} Node status is NotReady and {{ $labels.status }}'
+          - alert: K8SManyNodesNotReady
+            expr: count(kube_node_status_condition{condition="Ready", status="unknown"} == 1) > 1 and (count(kube_node_status_condition{condition="Ready", status="unknown"} == 1) / count(kube_node_status_condition{condition="Ready", status="unknown"})) > 0.2
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: '{{ $value }} Kubernetes nodes (more than 10% are in the NotReady state).'
+              summary: Many Kubernetes nodes are Not Ready
+          - alert: K8SManyNodesNotReady
+            expr: count(kube_node_status_condition{condition="Ready", status="false"} == 1) > 1 and (count(kube_node_status_condition{condition="Ready", status="false"} == 1) / count(kube_node_status_condition{condition="Ready", status="false"})) > 0.2
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: '{{ $value }} Kubernetes nodes (more than 10% are in the NotReady state).'
+              summary: Many Kubernetes nodes are Not Ready
+          - alert: K8SNodesNotReady
+            expr: count(kube_node_status_condition{condition="Ready", status="false"} == 1) > 0 or count(kube_node_status_condition{condition="Ready", status="unknown"} == 1) > 0
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: '{{ $value }} nodes are notReady state.'
+              summary: One or more Kubernetes nodes are Not Ready
+          - alert: K8SKubeletDown
+            expr: count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) > 0.03
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: Prometheus failed to scrape {{ $value }}% of kubelets.
+              summary: Many Kubelets cannot be scraped
+          - alert: K8SKubeletDown
+            expr: absent(up{job="kubelet"} == 1) or count(up{job="kubelet"} == 0) / count(up{job="kubelet"}) > 0.1
+            for: 1m
+            labels:
+              severity: critical
+            annotations:
+              description: Prometheus failed to scrape {{ $value }}% of kubelets, or all Kubelets have disappeared from service discovery.
+              summary: Many Kubelets cannot be scraped
+          - alert: K8SKubeletTooManyPods
+            expr: kubelet_running_pod_count > 100
+            labels:
+              severity: warning
+            annotations:
+              description: Kubelet {{$labels.instance}} is running {{$value}} pods, close to the limit of 110
+              summary: Kubelet is close to pod limit
+        - name: kube-apiserver.rules
+          rules:
+          - alert: K8SApiserverDown
+            expr: absent(up{job="apiserver"} == 1)
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              description: Prometheus failed to scrape API server(s), or all API servers have disappeared from service discovery.
+              summary: API server unreachable
+          - alert: K8SApiServerLatency
+            expr: histogram_quantile(0.99, sum(apiserver_request_latencies_bucket{verb!~"CONNECT|WATCHLIST|WATCH|PROXY"}) WITHOUT (instance, resource)) / 1e+06 > 1
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 99th percentile Latency for {{ $labels.verb }} requests to the kube-apiserver is higher than 1s.
+              summary: Kubernetes apiserver latency is high
+        - name: kube-controller-manager.rules
+          rules:
+          - alert: K8SControllerManagerDown
+            expr: absent(up{job="kube-controller-manager-discovery"} == 1)
+            for: 5m
+            labels:
+              severity: critical
+            annotations:
+              description: There is no running K8S controller manager. Deployments and replication controllers are not making progress.
+              runbook: https://coreos.com/tectonic/docs/latest/troubleshooting/controller-recovery.html#recovering-a-controller-manager
+              summary: Controller manager is down
+        - name: kubernetes-object.rules
+          rules:
+          - alert: prom_exporter_kube_state_metrics_unavailable
+            expr: avg_over_time(up{job="kube-state-metrics"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: kube-state-metrics exporter is not collecting metrics or is not available for past 10 minutes
+              title: kube-state-metrics exporter is not collecting metrics or is not available
+          - alert: kube_statefulset_replicas_unavailable
+            expr: kube_statefulset_status_replicas < kube_statefulset_replicas
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'statefulset {{$labels.statefulset}} has {{$value}} replicas, which is less than desired'
+              summary: '{{$labels.statefulset}}: has inssuficient replicas.'
+          - alert: daemonsets_misscheduled
+            expr: kube_daemonset_status_number_misscheduled > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Daemonset {{$labels.daemonset}} is running where it is not supposed to run'
+              summary: 'Daemonsets not scheduled correctly'
+          - alert: daemonsets_not_scheduled
+            expr: kube_daemonset_status_desired_number_scheduled - kube_daemonset_status_current_number_scheduled > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{ $value }} of Daemonset {{$labels.daemonset}} scheduled which is less than desired number'
+              summary: 'Less than desired number of daemonsets scheduled'
+          - alert: daemonset_pods_unavailable
+            expr: kube_daemonset_status_number_unavailable > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Daemonset {{$labels.daemonset}} currently has pods unavailable'
+              summary: 'Daemonset pods unavailable, due to one of many reasons'
+          - alert: deployment_replicas_unavailable
+            expr: kube_deployment_status_replicas_unavailable > 0
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'deployment {{$labels.deployment}} has {{$value}} replicas unavailable'
+              summary: '{{$labels.deployment}}: has inssuficient replicas.'
+          - alert: rollingupdate_deployment_replica_less_than_spec_max_unavailable
+            expr: kube_deployment_status_replicas_available - kube_deployment_spec_strategy_rollingupdate_max_unavailable < 0
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'deployment {{$labels.deployment}} has {{$value}} replicas available which is less than specified as max unavailable during a rolling update'
+              summary: '{{$labels.deployment}}: has inssuficient replicas during a rolling update.'
+          - alert: job_status_failed
+            expr: kube_job_status_failed > 0
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Job {{$labels.exported_job}} is in failed status'
+              summary: '{{$labels.exported_job}} has failed status'
+          - alert: pod_status_pending
+            expr: kube_pod_status_phase{phase="Pending"} == 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has been in pending status for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in pending status'
+          - alert: pod_status_error_image_pull
+            expr: kube_pod_container_status_waiting_reason {reason="ErrImagePull"} == 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has an Image pull error for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status'
+          - alert: pod_status_error_image_pull_backoff
+            expr: kube_pod_container_status_waiting_reason {reason="ImagePullBackOff"} == 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has an ImagePullBackOff error for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status'
+          - alert: pod_error_crash_loop_back_off
+            expr: kube_pod_container_status_waiting_reason {reason="CrashLoopBackOff"} == 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has an CrashLoopBackOff  error for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status'
+          - alert: pod_error_config_error
+            expr: kube_pod_container_status_waiting_reason {reason="CreateContainerConfigError"} == 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has a CreateContainerConfigError error for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status'
+          - alert: replicaset_missing_replicas
+            expr: kube_replicaset_spec_replicas -  kube_replicaset_status_ready_replicas > 0
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Replicaset {{$labels.replicaset}} is missing desired number of replicas for more than 10 minutes'
+              summary: 'Replicaset {{$labels.replicaset}} is missing replicas'
+          - alert: pod_container_terminated
+            expr: kube_pod_container_status_terminated_reason{reason=~"OOMKilled|Error|ContainerCannotRun"} > 0
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} has a container terminated for more than 10 minutes'
+              summary: 'Pod {{$labels.pod}} in namespace {{$labels.namespace}} in error status'
+          - alert: volume_claim_capacity_high_utilization
+            expr: 100 * kubelet_volume_stats_used_bytes / kubelet_volume_stats_capacity_bytes > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'volume claim {{$labels.persistentvolumeclaim}} usage has exceeded 80% of total capacity'
+              summary: '{{$labels.persistentvolumeclaim}} usage has exceeded 80% of total capacity.'
+...

--- a/prometheus/values_overrides/local-storage.yaml
+++ b/prometheus/values_overrides/local-storage.yaml
@@ -1,0 +1,9 @@
+---
+pod:
+  replicas:
+    prometheus: 1
+storage:
+  requests:
+    storage: 1Gi
+  storage_class: local-storage
+...

--- a/prometheus/values_overrides/nodes.yaml
+++ b/prometheus/values_overrides/nodes.yaml
@@ -1,0 +1,245 @@
+---
+conf:
+  prometheus:
+    rules:
+      nodes:
+        groups:
+        - name: node.recording_rules
+          rules:
+          - record: node_filesystem_free_percent
+            expr: 100 * {fstype =~ "xfs|ext[34]"} / node_filesystem_size{fstype =~ "xfs|ext[34]"}
+          - record: node_ram_usage_percent
+            expr: 100 * (node_memory_MemFree + node_memory_Buffers + node_memory_Cached) / node_memory_MemTotal
+          - record: node_swap_usage_percent
+            expr: 100 * (node_memory_SwapFree + node_memory_SwapCached) / node_memory_SwapTotal
+        - name: nodes.alerting_rules
+          rules:
+          - alert: prom_exporter_node_unavailable
+            expr: avg_over_time(up{job="node-exporter"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: node exporter is not collecting metrics or is not available for past 10 minutes
+              title: node exporter is not collecting metrics or is not available
+          - alert: node_filesystem_full_80percent
+            expr: avg_over_time(node_filesystem_free_percent[2m]) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}}
+                has less than 20% free space left.'
+              summary: '{{$labels.alias}}: Filesystem is running out of space soon.'
+          - alert: node_filesystem_full_in_4h
+            expr: predict_linear(node_filesystem_free{fstype =~ "xfs|ext[34]"}[1h], 4 * 3600) <= 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} device {{$labels.device}} on {{$labels.mountpoint}}
+                is running out of space of in approx. 4 hours'
+              summary: '{{$labels.alias}}: Filesystem is running out of space in 4 hours.'
+          - alert: node_filedescriptors_full_in_3h
+            expr: predict_linear(node_filefd_allocated[1h], 3 * 3600) >= node_filefd_maximum
+            for: 20m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} is running out of available file descriptors
+                in approx. 3 hours'
+              summary: '{{$labels.alias}} is running out of available file descriptors in
+                3 hours.'
+          - alert: node_load1_90percent
+            expr: node_load1 / ON(alias) count(node_cpu{mode="system"}) BY (alias) >= 0.9
+            for: 1h
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} is running with > 90% total load for at least
+                1h.'
+              summary: '{{$labels.alias}}: Running on high load.'
+          - alert: node_cpu_util_90percent
+            expr: 100 - (avg(irate(node_cpu{mode="idle"}[5m])) BY (alias) * 100) >= 90
+            for: 1h
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} has total CPU utilization over 90% for at least
+                1h.'
+              summary: '{{$labels.alias}}: High CPU utilization.'
+          - alert: node_ram_using_90percent
+            expr: avg_over_time(node_ram_usage_percent[2m]) > 90
+            for: 30m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} is using at least 90% of its RAM for at least
+                30 minutes now.'
+              summary: '{{$labels.alias}}: Using lots of RAM.'
+          - alert: node_swap_using_80percent
+            expr: avg_over_time(node_swap_usage_percent[2m]) > 80
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} is using 80% of its swap space for at least
+                10 minutes now.'
+              summary: '{{$labels.alias}}: Running out of swap soon.'
+          - alert: node_high_cpu_load
+            expr: node_load15 / on(alias) count(node_cpu{mode="system"}) by (alias) >= 0
+            for: 1m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{$labels.alias}} is running with load15 > 1 for at least 5 minutes: {{$value}}'
+              summary: '{{$labels.alias}}: Running on high load: {{$value}}'
+          - alert: node_high_memory_load
+            expr: avg_over_time(node_ram_usage_percent[2m]) > 85
+            for: 1m
+            labels:
+              severity: warning
+            annotations:
+              description: Host memory usage is {{ humanize $value }}%. Reported by
+                instance {{ $labels.instance }} of job {{ $labels.job }}.
+              summary: Server memory is almost full
+          - alert: node_high_storage_load
+            expr: avg_over_time(node_storage_usage_percent{mountpoint="/"}[2m]) > 85
+            for: 30s
+            labels:
+              severity: warning
+            annotations:
+              description: Host storage usage is {{ humanize $value }}%. Reported by
+                instance {{ $labels.instance }} of job {{ $labels.job }}.
+              summary: Server storage is almost full
+          - alert: node_high_swap
+            expr: (node_memory_SwapTotal - node_memory_SwapFree) < (node_memory_SwapTotal
+              * 0.4)
+            for: 1m
+            labels:
+              severity: warning
+            annotations:
+              description: Host system has a high swap usage of {{ humanize $value }}. Reported
+                by instance {{ $labels.instance }} of job {{ $labels.job }}.
+              summary: Server has a high swap usage
+          - alert: node_high_network_drop_rcv
+            expr: node_network_receive_drop{device!="lo"} > 3000
+            for: 30s
+            labels:
+              severity: warning
+            annotations:
+              description: Host system has an unusally high drop in network reception ({{
+                humanize $value }}). Reported by instance {{ $labels.instance }} of job {{
+                $labels.job }}
+              summary: Server has a high receive drop
+          - alert: node_high_network_drop_send
+            expr: node_network_transmit_drop{device!="lo"} > 3000
+            for: 30s
+            labels:
+              severity: warning
+            annotations:
+              description: Host system has an unusally high drop in network transmission ({{
+                humanize $value }}). Reported by instance {{ $labels.instance }} of job {{
+                $labels.job }}
+              summary: Server has a high transmit drop
+          - alert: node_high_network_errs_rcv
+            expr: node_network_receive_errs{device!="lo"} > 3000
+            for: 30s
+            labels:
+              severity: warning
+            annotations:
+              description: Host system has an unusally high error rate in network reception
+                ({{ humanize $value }}). Reported by instance {{ $labels.instance }} of job
+                {{ $labels.job }}
+              summary: Server has unusual high reception errors
+          - alert: node_high_network_errs_send
+            expr: node_network_transmit_errs{device!="lo"} > 3000
+            for: 30s
+            labels:
+              severity: warning
+            annotations:
+              description: Host system has an unusally high error rate in network transmission
+                ({{ humanize $value }}). Reported by instance {{ $labels.instance }} of job
+                {{ $labels.job }}
+              summary: Server has unusual high transmission errors
+          - alert: node_network_conntrack_usage_80percent
+            expr: sort(node_nf_conntrack_entries{job="node-exporter"} > node_nf_conntrack_entries_limit{job="node-exporter"}  * 0.8)
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.instance}} has network conntrack entries of {{ $value }} which is more than 80% of maximum limit'
+              summary: '{{$labels.instance}}: available network conntrack entries are low.'
+          - alert: node_entropy_available_low
+            expr: node_entropy_available_bits < 300
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.instance}} has available entropy bits of {{ $value }} which is less than required of 300'
+              summary: '{{$labels.instance}}: is low on entropy bits.'
+          - alert: node_hwmon_high_cpu_temp
+            expr: node_hwmon_temp_crit_celsius*0.9 - node_hwmon_temp_celsius < 0 OR node_hwmon_temp_max_celsius*0.95 - node_hwmon_temp_celsius < 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} reports hwmon sensor {{$labels.sensor}}/{{$labels.chip}} temperature value is nearly critical: {{$value}}'
+              summary: '{{$labels.alias}}: Sensor {{$labels.sensor}}/{{$labels.chip}} temp is high: {{$value}}'
+          - alert: node_vmstat_paging_rate_high
+            expr: irate(node_vmstat_pgpgin[5m]) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} has a memory paging rate of change higher than 80%: {{$value}}'
+              summary: '{{$labels.alias}}: memory paging rate is high: {{$value}}'
+          - alert: node_xfs_block_allocation_high
+            expr: 100*(node_xfs_extent_allocation_blocks_allocated_total{job="node-exporter", instance=~"172.17.0.1.*"} / (node_xfs_extent_allocation_blocks_freed_total{job="node-exporter", instance=~"172.17.0.1.*"} + node_xfs_extent_allocation_blocks_allocated_total{job="node-exporter", instance=~"172.17.0.1.*"})) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} has xfs allocation blocks higher than 80%: {{$value}}'
+              summary: '{{$labels.alias}}: xfs block allocation high: {{$value}}'
+          - alert: node_network_bond_slaves_down
+            expr: node_net_bonding_slaves - node_net_bonding_slaves_active > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{ $labels.master }} is missing {{ $value }} slave interface(s).'
+              summary: 'Instance {{ $labels.instance }}: {{ $labels.master }} missing {{ $value }} slave interface(s)'
+          - alert: node_numa_memory_used
+            expr: 100*node_memory_numa_MemUsed / node_memory_numa_MemTotal > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} has more than 80% NUMA memory usage: {{ $value }}'
+              summary: '{{$labels.alias}}: has high NUMA memory usage: {{$value}}'
+          - alert: node_ntp_clock_skew_high
+            expr: abs(node_ntp_drift_seconds) > 2
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.alias}} has time difference of more than 2 seconds compared to NTP server: {{ $value }}'
+              summary: '{{$labels.alias}}: time is skewed by : {{$value}} seconds'
+          - alert: node_disk_read_latency
+            expr: (rate(node_disk_read_time_ms[5m]) / rate(node_disk_reads_completed[5m])) > 40
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.device}} has a high read latency of {{ $value }}'
+              summary: 'High read latency observed for device {{ $labels.device }}'
+          - alert: node_disk_write_latency
+            expr: (rate(node_disk_write_time_ms[5m]) / rate(node_disk_writes_completed[5m])) > 40
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: '{{$labels.device}} has a high write latency of {{ $value }}'
+              summary: 'High write latency observed for device {{ $labels.device }}'
+...

--- a/prometheus/values_overrides/openstack.yaml
+++ b/prometheus/values_overrides/openstack.yaml
@@ -1,0 +1,325 @@
+---
+conf:
+  prometheus:
+    rules:
+      openstack:
+        groups:
+        - name: mariadb.rules
+          rules:
+          - alert: prom_exporter_mariadb_openstack_unavailable
+            expr: avg_over_time(up{job="mysql-exporter",kubernetes_namespace="openstack"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: MariaDB exporter in  {{ $labels.kubernetes_namespace }} is not collecting metrics or is not available for past 10 minutes
+              title: MariaDB exporter is not collecting metrics or is not available
+          - alert: prom_exporter_mariadb_osh_infra_unavailable
+            expr: avg_over_time(up{job="mysql-exporter",kubernetes_namespace="osh-infra"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: MariaDB exporter in  {{ $labels.kubernetes_namespace }} is not collecting metrics or is not available for past 10 minutes
+              title: MariaDB exporter is not collecting metrics or is not available
+          - alert: mariadb_table_lock_wait_high
+            expr: 100 * mysql_global_status_table_locks_waited/(mysql_global_status_table_locks_waited + mysql_global_status_table_locks_immediate) > 30
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'Mariadb has high table lock waits of {{ $value }} percentage'
+              summary: 'Mariadb table lock waits are high'
+          - alert: mariadb_node_not_ready
+            expr: mysql_global_status_wsrep_ready != 1
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{$labels.job}} on {{$labels.instance}} is not ready.'
+              summary: 'Galera cluster node not ready'
+          - alert: mariadb_galera_node_out_of_sync
+            expr: mysql_global_status_wsrep_local_state != 4 AND mysql_global_variables_wsrep_desync == 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: '{{$labels.job}} on {{$labels.instance}} is not in sync ({{$value}} != 4)'
+              summary: 'Galera cluster node out of sync'
+          - alert: mariadb_innodb_replication_fallen_behind
+            expr: (mysql_global_variables_innodb_replication_delay > 30) AND on (instance) (predict_linear(mysql_global_variables_innodb_replication_delay[5m], 60*2) > 0)
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'The mysql innodb replication has fallen behind and is not recovering'
+              summary: 'MySQL innodb replication is lagging'
+        - name: openstack.rules
+          rules:
+          - alert: prom_exporter_openstack_unavailable
+            expr: avg_over_time(up{job="openstack-metrics"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: Openstack exporter is not collecting metrics or is not available for past 10 minutes
+              title: Openstack exporter is not collecting metrics or is not available
+          - alert: os_glance_api_availability
+            expr: openstack_check_glance_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Glance API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Glance API is not available at {{$labels.url}}'
+          - alert: os_nova_api_availability
+            expr: openstack_check_nova_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Nova API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Nova API is not available at {{$labels.url}}'
+          - alert: os_keystone_api_availability
+            expr: openstack_check_keystone_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Keystone API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Keystone API is not available at {{$labels.url}}'
+          - alert: os_neutron_api_availability
+            expr: openstack_check_neutron_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Neutron API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Neutron API is not available at {{$labels.url}}'
+          - alert: os_neutron_metadata_agent_availability
+            expr: openstack_services_neutron_metadata_agent_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'One or more neutron metadata_agents are not available for more than 5 minutes'
+              summary: 'One or more neutron metadata_agents are not available'
+          - alert: os_neutron_openvswitch_agent_availability
+            expr: openstack_services_neutron_openvswitch_agent_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'One or more neutron openvswitch agents are not available for more than 5 minutes'
+              summary: 'One or more neutron openvswitch agents are not available'
+          - alert: os_neutron_dhcp_agent_availability
+            expr: openstack_services_neutron_dhcp_agent_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'One or more neutron dhcp agents are not available for more than 5 minutes'
+              summary: 'One or more neutron dhcp agents are not available'
+          - alert: os_neutron_l3_agent_availability
+            expr: openstack_services_neutron_l3_agent_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'One or more neutron L3 agents are not available for more than 5 minutes'
+              summary: 'One or more neutron L3 agents are not available'
+          - alert: os_swift_api_availability
+            expr: openstack_check_swift_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Swift API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Swift API is not available at {{$labels.url}}'
+          - alert: os_cinder_api_availability
+            expr: openstack_check_cinder_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Cinder API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Cinder API is not available at {{$labels.url}}'
+          - alert: os_cinder_scheduler_availability
+            expr: openstack_services_cinder_cinder_scheduler != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Cinder scheduler is not available for more than 5 minutes'
+              summary: 'Cinder scheduler is not available'
+          - alert: os_heat_api_availability
+            expr: openstack_check_heat_api != 1
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Heat API is not available at {{$labels.url}} for more than 5 minutes'
+              summary: 'Heat API is not available at {{$labels.url}}'
+          - alert: os_nova_compute_disabled
+            expr: openstack_services_nova_compute_disabled_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-compute is disabled on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-compute is disabled on some hosts'
+          - alert: os_nova_conductor_disabled
+            expr: openstack_services_nova_conductor_disabled_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-conductor is disabled on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-conductor is disabled on some hosts'
+          - alert: os_nova_consoleauth_disabled
+            expr: openstack_services_nova_consoleauth_disabled_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-consoleauth is disabled on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-consoleauth is disabled on some hosts'
+          - alert: os_nova_scheduler_disabled
+            expr: openstack_services_nova_scheduler_disabled_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-scheduler is disabled on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-scheduler is disabled on some hosts'
+          - alert: os_nova_compute_down
+            expr: openstack_services_nova_compute_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-compute is down on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-compute is down on some hosts'
+          - alert: os_nova_conductor_down
+            expr: openstack_services_nova_conductor_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-conductor is down on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-conductor is down on some hosts'
+          - alert: os_nova_consoleauth_down
+            expr: openstack_services_nova_consoleauth_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-consoleauth is down on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-consoleauth is down on some hosts'
+          - alert: os_nova_scheduler_down
+            expr: openstack_services_nova_scheduler_down_total > 0
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'nova-scheduler is down on certain hosts for more than 5 minutes'
+              summary: 'Openstack compute service nova-scheduler is down on some hosts'
+          - alert: os_vm_vcpu_usage_high
+            expr: openstack_total_used_vcpus * 100/(openstack_total_used_vcpus + openstack_total_free_vcpus) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Openstack VM vcpu usage is hight at {{$value}} percent'
+              summary: 'Openstack VM vcpu usage is high'
+          - alert: os_vm_ram_usage_high
+            expr: openstack_total_used_ram_MB * 100/(openstack_total_used_ram_MB + openstack_total_free_ram_MB) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Openstack VM RAM usage is hight at {{$value}} percent'
+              summary: 'Openstack VM RAM usage is high'
+          - alert: os_vm_disk_usage_high
+            expr: openstack_total_used_disk_GB * 100/ ( openstack_total_used_disk_GB + openstack_total_free_disk_GB ) > 80
+            for: 5m
+            labels:
+              severity: page
+            annotations:
+              description: 'Openstack VM Disk usage is hight at {{$value}} percent'
+              summary: 'Openstack VM Disk usage is high'
+        - name: rabbitmq.rules
+          rules:
+          - alert: rabbitmq_network_pratitions_detected
+            expr: min(partitions) by(instance) > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ at {{ $labels.instance }} has {{ $value }} partitions'
+              summary: 'RabbitMQ Network partitions detected'
+          - alert: rabbitmq_down
+            expr: min(rabbitmq_up) by(instance) != 1
+            for: 10m
+            labels:
+              severity: page
+            annotations:
+              description: 'RabbitMQ Server instance {{ $labels.instance }} is down'
+              summary: 'The RabbitMQ Server instance at {{ $labels.instance }} has been down the last 10 mins'
+          - alert: rabbitmq_file_descriptor_usage_high
+            expr: fd_used * 100 /fd_total > 80
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ Server instance {{ $labels.instance }} has high file descriptor usage of {{ $value }} percent.'
+              summary: 'RabbitMQ file descriptors usage is high for last 10 mins'
+          - alert: rabbitmq_node_disk_free_alarm
+            expr: node_disk_free_alarm > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ Server instance {{ $labels.instance }} has low disk free space available.'
+              summary: 'RabbitMQ disk space usage is high'
+          - alert: rabbitmq_node_memory_alarm
+            expr: node_mem_alarm > 0
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ Server instance {{ $labels.instance }} has low free memory.'
+              summary: 'RabbitMQ memory usage is high'
+          - alert: rabbitmq_less_than_3_nodes
+            expr: running < 3
+            for: 10m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ Server has less than 3 nodes running.'
+              summary: 'RabbitMQ server is at risk of loosing data'
+          - alert: rabbitmq_queue_messages_returned_high
+            expr: queue_messages_returned_total/queue_messages_published_total * 100 > 50
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ Server is returing more than 50 percent of messages received.'
+              summary: 'RabbitMQ server is returning more than 50 percent of messages received.'
+          - alert: rabbitmq_consumers_low_utilization
+            expr: queue_consumer_utilisation < .4
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ consumers message consumption speed is low'
+              summary: 'RabbitMQ consumers message consumption speed is low'
+          - alert: rabbitmq_high_message_load
+            expr: queue_messages_total > 17000 or increase(queue_messages_total[5m]) > 4000
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: 'RabbitMQ has high message load. Total Queue depth > 17000 or growth more than 4000 messages.'
+              summary: 'RabbitMQ has high message load'
+...

--- a/prometheus/values_overrides/postgresql.yaml
+++ b/prometheus/values_overrides/postgresql.yaml
@@ -1,0 +1,41 @@
+---
+conf:
+  prometheus:
+    rules:
+      postgresql:
+        groups:
+        - name: postgresql.rules
+          rules:
+          - alert: prom_exporter_postgresql_unavailable
+            expr: avg_over_time(up{job="postgresql-exporter"}[5m]) == 0
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: postgresql exporter is not collecting metrics or is not available for past 10 minutes
+              title: postgresql exporter is not collecting metrics or is not available
+          - alert: pg_replication_fallen_behind
+            expr: (pg_replication_lag > 120) and ON(instance) (pg_replication_is_replica ==  1)
+            for: 5m
+            labels:
+              severity: warning
+            annotations:
+              description: Replication lag on server {{$labels.instance}} is currently {{$value | humanizeDuration }}
+              title: Postgres Replication lag is over 2 minutes
+          - alert: pg_connections_too_high
+            expr: sum(pg_stat_activity_count) BY (environment, fqdn) > ON(fqdn) pg_settings_max_connections * 0.95
+            for: 5m
+            labels:
+              severity: warn
+              channel: database
+            annotations:
+              title: Postgresql has {{$value}} connections on {{$labels.fqdn}} which is close to the maximum
+          - alert: pg_deadlocks_detected
+            expr: sum by(datname) (rate(pg_stat_database_deadlocks[1m])) > 0
+            for: 5m
+            labels:
+              severity: warn
+            annotations:
+              description: postgresql at {{$labels.instance}} is showing {{$value}} rate of deadlocks for database {{$labels.datname}}
+              title: Postgres server is experiencing deadlocks
+...

--- a/prometheus/values_overrides/tls.yaml
+++ b/prometheus/values_overrides/tls.yaml
@@ -1,0 +1,250 @@
+---
+endpoints:
+  monitoring:
+    host_fqdn_override:
+      default:
+        tls:
+          secretName: prometheus-tls-api
+          issuerRef:
+            name: ca-issuer
+            kind: ClusterIssuer
+    scheme:
+      default: "https"
+    port:
+      http:
+        default: 443
+network:
+  prometheus:
+    ingress:
+      annotations:
+        nginx.ingress.kubernetes.io/backend-protocol: https
+conf:
+  httpd: |
+    ServerRoot "/usr/local/apache2"
+    Listen 443
+    LoadModule mpm_event_module modules/mod_mpm_event.so
+    LoadModule authn_file_module modules/mod_authn_file.so
+    LoadModule authn_core_module modules/mod_authn_core.so
+    LoadModule authz_host_module modules/mod_authz_host.so
+    LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
+    LoadModule authz_user_module modules/mod_authz_user.so
+    LoadModule authz_core_module modules/mod_authz_core.so
+    LoadModule access_compat_module modules/mod_access_compat.so
+    LoadModule auth_basic_module modules/mod_auth_basic.so
+    LoadModule ldap_module modules/mod_ldap.so
+    LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+    LoadModule reqtimeout_module modules/mod_reqtimeout.so
+    LoadModule filter_module modules/mod_filter.so
+    LoadModule proxy_html_module modules/mod_proxy_html.so
+    LoadModule log_config_module modules/mod_log_config.so
+    LoadModule env_module modules/mod_env.so
+    LoadModule headers_module modules/mod_headers.so
+    LoadModule setenvif_module modules/mod_setenvif.so
+    LoadModule version_module modules/mod_version.so
+    LoadModule proxy_module modules/mod_proxy.so
+    LoadModule proxy_connect_module modules/mod_proxy_connect.so
+    LoadModule proxy_http_module modules/mod_proxy_http.so
+    LoadModule proxy_balancer_module modules/mod_proxy_balancer.so
+    LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
+    LoadModule slotmem_plain_module modules/mod_slotmem_plain.so
+    LoadModule unixd_module modules/mod_unixd.so
+    LoadModule status_module modules/mod_status.so
+    LoadModule autoindex_module modules/mod_autoindex.so
+    LoadModule ssl_module modules/mod_ssl.so
+
+    <IfModule unixd_module>
+    User daemon
+    Group daemon
+    </IfModule>
+
+    <Directory />
+        AllowOverride none
+        Require all denied
+    </Directory>
+
+    <Files ".ht*">
+        Require all denied
+    </Files>
+
+    ErrorLog /dev/stderr
+
+    LogLevel warn
+
+    <IfModule log_config_module>
+        LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" combined
+        LogFormat "%{X-Forwarded-For}i %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\"" proxy
+        LogFormat "%h %l %u %t \"%r\" %>s %b" common
+
+        <IfModule logio_module>
+          LogFormat "%a %l %u %t \"%r\" %>s %b \"%{Referer}i\" \"%{User-Agent}i\" %I %O" combinedio
+        </IfModule>
+
+        SetEnvIf X-Forwarded-For "^.*\..*\..*\..*" forwarded
+        CustomLog /dev/stdout common
+        CustomLog /dev/stdout combined
+        CustomLog /dev/stdout proxy env=forwarded
+    </IfModule>
+
+    <Directory "/usr/local/apache2/cgi-bin">
+        AllowOverride None
+        Options None
+        Require all granted
+    </Directory>
+
+    <IfModule headers_module>
+        RequestHeader unset Proxy early
+    </IfModule>
+
+    <IfModule proxy_html_module>
+    Include conf/extra/proxy-html.conf
+    </IfModule>
+
+    <VirtualHost *:443>
+      # Expose metrics to all users, as this is not sensitive information and
+      # circumvents the inability of Prometheus to interpolate environment vars
+      # in its configuration file
+      <Location /metrics>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          Satisfy Any
+          Allow from all
+      </Location>
+      # Expose the /federate endpoint to all users, as this is also not
+      # sensitive information and circumvents the inability of Prometheus to
+      # interpolate environment vars in its configuration file
+      <Location /federate>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/metrics
+          Satisfy Any
+          Allow from all
+      </Location>
+      # Restrict general user (LDAP) access to the /graph endpoint, as general trusted
+      # users should only be able to query Prometheus for metrics and not have access
+      # to information like targets, configuration, flags or build info for Prometheus
+      <Location />
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file ldap
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          AuthLDAPBindDN {{ .Values.endpoints.ldap.auth.admin.bind }}
+          AuthLDAPBindPassword {{ .Values.endpoints.ldap.auth.admin.password }}
+          AuthLDAPURL {{ tuple "ldap" "default" "ldap" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | quote }}
+          Require valid-user
+      </Location>
+      <Location /graph>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/graph
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/graph
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file ldap
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          AuthLDAPBindDN {{ .Values.endpoints.ldap.auth.admin.bind }}
+          AuthLDAPBindPassword {{ .Values.endpoints.ldap.auth.admin.password }}
+          AuthLDAPURL {{ tuple "ldap" "default" "ldap" . | include "helm-toolkit.endpoints.keystone_endpoint_uri_lookup" | quote }}
+          Require valid-user
+      </Location>
+      # Restrict access to the /config (dashboard) and /api/v1/status/config (http) endpoints
+      # to the admin user
+      <Location /config>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/config
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/config
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/status/config>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/config
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/config
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /flags (dashboard) and /api/v1/status/flags (http) endpoints
+      # to the admin user
+      <Location /flags>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/flags
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/flags
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/status/flags>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/flags
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/status/flags
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /status (dashboard) endpoint to the admin user
+      <Location /status>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/status
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/status
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /rules (dashboard) endpoint to the admin user
+      <Location /rules>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/rules
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/rules
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /targets (dashboard) and /api/v1/targets (http) endpoints
+      # to the admin user
+      <Location /targets>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/targets
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/targets
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      <Location /api/v1/targets>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/targets
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/targets
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      # Restrict access to the /api/v1/admin/tsdb/ endpoints (http) to the admin user.
+      # These endpoints are disabled by default, but are included here to ensure only
+      # an admin user has access to these endpoints when enabled
+      <Location /api/v1/admin/tsdb/>
+          ProxyPass http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/admin/tsdb/
+          ProxyPassReverse http://localhost:{{ tuple "monitoring" "internal" "api" . | include "helm-toolkit.endpoints.endpoint_port_lookup" }}/api/v1/admin/tsdb/
+          AuthName "Prometheus"
+          AuthType Basic
+          AuthBasicProvider file
+          AuthUserFile /usr/local/apache2/conf/.htpasswd
+          Require valid-user
+      </Location>
+      SSLEngine On
+      SSLProxyEngine on
+      SSLCertificateFile      /etc/prometheus/certs/tls.crt
+      SSLCertificateKeyFile   /etc/prometheus/certs/tls.key
+      SSLProtocol             all -SSLv3 -TLSv1 -TLSv1.1
+      SSLCipherSuite          ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA256
+      SSLHonorCipherOrder     on
+    </VirtualHost>
+manifests:
+  certificates: true
+...


### PR DESCRIPTION
Following components are added:
 * custom-metrics-generator which brings custom node metrics populated via node-exporter
 * custom-openstack-exporter an alternate openstack exporter
 * esaco OAuth introspection proxy
 * prometheus chart with thanos sidecar support
 * alertmanager with alert template support
