### PR TITLE
feat: egi-accounting uses fresh cASO image, node affinity fixed, ssm cert secret rendering fixed

### DIFF
--- a/egi-accounting/Chart.yaml
+++ b/egi-accounting/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 name: egi-accounting
-version: &version 0.2.1
+version: &version 0.4.4
 appVersion: *version
 description: EGI accounting
 home: https://accounting.egi.eu/

--- a/egi-accounting/templates/configmap-etc.yaml
+++ b/egi-accounting/templates/configmap-etc.yaml
@@ -8,12 +8,12 @@ data:
 
   caso.conf: |
     [DEFAULT]
-    {{- range $key, $val := .Values.caso.config.default }}
+    {{- range $key, $val := .Values.caso.config.DEFAULT }}
     {{ $key }} = {{ $val }}
     {{- end }}
 
     [keystone_auth]
-    {{- range $key, $val := .Values.caso.config.keystone_authtoken }}
+    {{- range $key, $val := .Values.caso.config.keystone_auth }}
     {{ $key }} = {{ $val }}
     {{- end }}
 

--- a/egi-accounting/templates/cronjob-caso.yaml
+++ b/egi-accounting/templates/cronjob-caso.yaml
@@ -36,16 +36,8 @@ spec:
               - name: accounting
                 mountPath: /var/spool/apel
           restartPolicy: OnFailure
+{{- if .Values.caso.affinity }}
           affinity:
-            podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 50
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app.kubernetes.io/name
-                      operator: In
-                      values:
-                      - {{ .Values.name }}-ssm
-                  topologyKey: kubernetes.io/hostname
+{{- toYaml .Values.caso.affinity | nindent 12 }}
+{{- end }}
 {{- end }}

--- a/egi-accounting/templates/cronjob-ssm.yaml
+++ b/egi-accounting/templates/cronjob-ssm.yaml
@@ -42,16 +42,8 @@ spec:
                 subPath: grid_security_key
                 readOnly: true
           restartPolicy: OnFailure
+{{- if .Values.ssm.affinity }}
           affinity:
-            podAffinity:
-              preferredDuringSchedulingIgnoredDuringExecution:
-              - weight: 50
-                podAffinityTerm:
-                  labelSelector:
-                    matchExpressions:
-                    - key: app.kubernetes.io/name
-                      operator: In
-                      values:
-                      - {{ .Values.name }}-caso
-                  topologyKey: kubernetes.io/hostname
+{{- toYaml .Values.ssm.affinity | nindent 12 }}
+{{- end }}
 {{- end }}

--- a/egi-accounting/templates/secret-ssm-certs.yaml
+++ b/egi-accounting/templates/secret-ssm-certs.yaml
@@ -4,6 +4,6 @@ kind: Secret
 metadata:
   name: {{ .Values.name }}-ssm-certs
 stringData:
-  grid_security_cert: {{ .Values.ssm.certs.grid_security_cert }}
-  grid_security_key: {{ .Values.ssm.certs.grid_security_key }}
+  grid_security_cert: {{ .Values.ssm.certs.grid_security_cert | quote }}
+  grid_security_key: {{ .Values.ssm.certs.grid_security_key | quote }}
 {{- end }}

--- a/egi-accounting/values.yaml
+++ b/egi-accounting/values.yaml
@@ -1,19 +1,18 @@
-name: egi-accounting
+name: &name egi-accounting
 
-persistence: # TODO: refactor if really needed
+persistence:
   storageClass: default
-  size: 3Gi
+  size: 100Mi
 
 caso:
   enabled: true
   schedule: "0 * * * *"
-  image: egifedcloud/caso
-  tag: v0.16
+  image: registry.gitlab.ics.muni.cz:443/cloud/g2/custom-images/caso
+  tag: "4.2.0-2"
   config: # https://github.com/enolfc/fedcloudappliance/blob/master/accounting/caso/caso.conf
     default:
-      messengers: ssmv4
+      messengers: ssm
       site_name: SITE-NAME
-      projects: demo
     keystone_auth:
       auth_type: v3password
       auth_url: https://yourkeystone/v3
@@ -22,6 +21,7 @@ caso:
 #  voms:
 #    vo:
 #      projects: ['1', '2']
+  affinity: null
 
 ssm:
   enabled: true
@@ -50,3 +50,4 @@ ssm:
       logfile: /var/log/apel/ssmsend.log
       level: DEBUG
       console: true
+  affinity: null


### PR DESCRIPTION
This PR introduces:
 * keep helm values keys 1:1 to ini file sections
 * support k8s affinities
 * fix ssm secret assignment
 * fix: avoid default cASO versioned messengers (deprecated)
 * upgrade cASO container image